### PR TITLE
Add Angular specific selectors for Message and Avatar

### DIFF
--- a/src/styles/Avatar.scss
+++ b/src/styles/Avatar.scss
@@ -42,10 +42,26 @@
 
 .str-chat__message {
   &--me {
-    > .str-chat__avatar {
+    %order {
       order: 1;
+    }
+
+    %margin {
       margin: 0;
       margin-left: var(--xs-m);
+    }
+
+    > .str-chat__avatar {
+      @extend %order;
+      @extend %margin;
+    }
+
+    > .str-chat-angular__avatar-host {
+      @extend %order;
+
+      > .str-chat__avatar {
+        @extend %margin;
+      }
     }
   }
 }

--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -864,7 +864,8 @@
     color: var(--overlay-dark);
   }
 
-  > .str-chat__avatar {
+  > .str-chat__avatar,
+  > .str-chat-angular__avatar-host > .str-chat__avatar {
     align-self: flex-end;
     margin-right: 0;
   }


### PR DESCRIPTION
Some selectors need to be extended because Angular and React handle components differently, Angular always adds a host element to the DOM tree when rendering a component, React doesn't have this functionality. This PR will contain the modifications from this week's sprint.