### PR TITLE
fix: replace font loading from google by the default system stack

### DIFF
--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:400,400i,700,700i');
-
 .str-chat {
   box-sizing: border-box;
 
@@ -14,16 +12,6 @@
 .clearfix {
   clear: both;
 }
-
-// button {
-//   cursor: pointer;
-//   background-color: transparent;
-//   border: none;
-//   padding: 0;
-//   display: flex;
-//   align-items: center;
-//   width: auto;
-// }
 
 .messenger-chat {
   &.str-chat {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,5 +1,9 @@
 /* fonts */
-$main-font: 'IBM Plex Sans', sans-serif;
+/* https://systemfontstack.com/ */
+$system-stack-font: -apple-system, BlinkMacSystemFont, "Segoe UI",
+                    Roboto, Oxygen-Sans, Ubuntu, Cantarell,
+                    "Helvetica Neue", sans-serif;
+$main-font: #{$system-stack-font};
 $second-font: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
 $base-font-weight: 400;


### PR DESCRIPTION
### 🎯 Goal

Avoid performing HTTP requests to Google API to load fonts and use the system defaults instead. Developers should have possibility to choose their own fonts without performing redundant HTTP calls.