### PR TITLE
Fix giphy sizing

### DIFF
--- a/src/styles/Attachment.scss
+++ b/src/styles/Attachment.scss
@@ -33,6 +33,11 @@
     padding: 0;
   }
 
+  /** Let giphies stretch their containers */
+  &-attachment--giphy {
+    max-width: unset;
+  }
+
   &--me {
     .str-chat__message-attachment {
       padding-left: 0;


### PR DESCRIPTION
The sizing of the giphies can now be configured using the `giphyVersion` property. See https://github.com/GetStream/stream-chat-react/commit/0d97fc62d4e5f166162e1d375689196305fad420

@szuperaz - not sure if this will affect Angular. 