### PR TITLE
refactor: Adjust style of .str-chat__header-hamburger icon to target svg

### DIFF
--- a/src/styles/ChannelHeader.scss
+++ b/src/styles/ChannelHeader.scss
@@ -272,7 +272,7 @@
 
   &:hover {
     svg path {
-       fill: var(--primary-color);
+      fill: var(--primary-color);
     }
   }
 

--- a/src/styles/ChannelHeader.scss
+++ b/src/styles/ChannelHeader.scss
@@ -263,27 +263,20 @@
 .str-chat__header-hamburger {
   width: 30px;
   height: 38px;
-  padding: var(--xs-p) var(--xs-p) var(--xs-p) 0;
+  padding: var(--xxs-p);
   margin-right: var(--xs-m);
   display: none;
-  flex-direction: column;
-  justify-content: space-around;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
 
   &:hover {
-    .str-chat__header-hamburger--line {
-      background: var(--primary-color);
+    svg path {
+       fill: var(--primary-color);
     }
   }
 
   @media screen and (max-width: 960px) {
     display: flex;
   }
-}
-
-.str-chat__header-hamburger--line {
-  width: 100%;
-  height: 2px;
-  background: var(--primary-color);
-  border-radius: var(--border-radius-sm);
 }


### PR DESCRIPTION
Adjust styling of hamburger icon in the `ChannelHeader` according to changes in [stream-chat-react](https://github.com/GetStream/stream-chat-react/pull/1392):

- remove .str-chat__header-hamburger--line selector and associated rules
- add rules targeting `.str-chat__header-hamburger` and the child  svg