### PR TITLE
fix: word overflow in message an quoted message

### DIFF
--- a/src/styles/Attachment.scss
+++ b/src/styles/Attachment.scss
@@ -166,7 +166,7 @@
   }
 
   &--media {
-    width: 300px;
+    max-width: 300px;
   }
 
   &-card {

--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -550,9 +550,6 @@
     font-weight: var(--font-weight-bold);
   }
 
-  &-url-link {
-  }
-
   &--inner {
     display: flex;
     flex-direction: column;
@@ -766,7 +763,9 @@
         font-weight: var(--font-weight-bold);
         text-decoration: none;
 
-        &:active, &:focus, &:hover {
+        &:active,
+        &:focus,
+        &:hover {
           text-decoration: underline;
         }
       }

--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -1196,7 +1196,6 @@
   // fixes the overall overflow/flex issues together with the rule above
   .mml-wrap {
     display: block;
-    max-width: none;
     // the max-width should match that to .str-chat__message-XXXX-text-inner
     max-width: 345px;
 

--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -377,12 +377,9 @@
       }
 
       p {
-        /* Make sure really long urls and words don't break out.
-        ** https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/ */
-        overflow-wrap: break-word;
+        /* Make sure really long urls and words don't break out.*/
         word-wrap: break-word;
-        overflow: hidden;
-        text-overflow: ellipsis;
+        word-break: break-word;
 
         /* Adds a hyphen where the word breaks, if supported (No Blink) */
         -ms-hyphens: auto;
@@ -554,10 +551,6 @@
   }
 
   &-url-link {
-    max-width: 150px;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
   }
 
   &--inner {
@@ -753,7 +746,8 @@
       flex: initial;
       text-align: left;
       max-width: 460px;
-      word-break: break-all;
+      word-wrap: break-word;
+      word-break: break-word;
 
       &.str-chat__message-simple-text-inner--is-emoji {
         background: transparent;
@@ -771,6 +765,10 @@
         color: var(--primary-color);
         font-weight: var(--font-weight-bold);
         text-decoration: none;
+
+        &:active, &:focus, &:hover {
+          text-decoration: underline;
+        }
       }
 
       blockquote {

--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -753,6 +753,7 @@
       flex: initial;
       text-align: left;
       max-width: 460px;
+      word-break: break-all;
 
       &.str-chat__message-simple-text-inner--is-emoji {
         background: transparent;

--- a/src/styles/MessageInputFlat.scss
+++ b/src/styles/MessageInputFlat.scss
@@ -44,6 +44,7 @@
           text-align: start;
           align-items: flex-end;
           word-break: break-all;
+          word-wrap: break-word;
 
           .str-chat__message-attachment {
             margin: 0;

--- a/src/styles/MessageInputFlat.scss
+++ b/src/styles/MessageInputFlat.scss
@@ -43,6 +43,7 @@
           display: flex;
           text-align: start;
           align-items: flex-end;
+          word-break: break-all;
 
           .str-chat__message-attachment {
             margin: 0;

--- a/src/styles/Thread.scss
+++ b/src/styles/Thread.scss
@@ -3,7 +3,6 @@
   flex: 1 0 300px;
   min-width: 300px;
   max-width: 300px;
-  overflow-y: hidden;
   font-family: var(--second-font);
   overflow: hidden;
   max-height: 100%;
@@ -223,6 +222,11 @@
         }
       }
     }
+  }
+
+  /** Quoted message preview in thread should not be squeezed to less than 100% for better readability */
+  .str-chat__input-flat-quoted .quoted-message-preview-content {
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
### 🎯 Goal

Fix visual bugs related to overflow in various message types.

fixes #67 

### Reply overflow fix
*Fixes: 1. Quoted message doesn't have the correct word-wrapping*

In MessageList:
![image](https://user-images.githubusercontent.com/32706194/159208501-f1c19537-51f3-40ed-8fbf-b885273fe2b2.png)

In Thread:
*Note: Preview width has been set to 100% for better readability.*
![image](https://user-images.githubusercontent.com/32706194/159243129-562331ea-2ec0-4a25-a564-1344f8c11a98.png)

### URL preview fix:
*Fixes: 2. URL preview in thread overflows*

With OG image
![image](https://user-images.githubusercontent.com/32706194/159240156-5fbdcc16-e4e9-4ac7-afdd-5aaa48770cc5.png)

Without OG image
![image](https://user-images.githubusercontent.com/32706194/159240297-8837e490-7642-435a-b889-4946fc1ae750.png)

### Video preview fix:
*Fixes: 3. Video preview overflows*
![image](https://user-images.githubusercontent.com/32706194/159240500-0a3b53ee-aa87-4b4c-81a0-095b2bb02aae.png)


### File preview fix:
*Fixes: 4. 
![image](https://user-images.githubusercontent.com/32706194/159236487-a76f2345-0347-4b95-9e77-337a1b90aa92.png)


## Out of scope

File upload preview in small message input overflows. The issue can be solved be reusing `MessageInputFlat` in the thread.

![image](https://user-images.githubusercontent.com/32706194/159252536-382ab2dd-8f89-4712-b98b-ab8ee5e6d5c4.png)

