### PR TITLE
fix: Remove unnecessary margin from error messages

### DIFF
--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -655,7 +655,6 @@
   /* error messages */
   &--error,
   &--failed {
-    margin: 0 0 var(--lg-m) var(--xl-m);
     font-size: var(--sm-font);
     padding: var(--xxs-p) 0;
 


### PR DESCRIPTION
Error message display is broken both for React and Angular

Before fix:
React:
![Screenshot 2022-04-05 at 15 16 02](https://user-images.githubusercontent.com/6690098/161766258-008b353b-f64a-4ac1-9552-3b679f9fb81e.png)
Angular:
![Screenshot 2022-04-05 at 15 14 36](https://user-images.githubusercontent.com/6690098/161766284-a15bd768-c462-4c76-8e39-796c69261876.png)

After fix:
React:
![Screenshot 2022-04-05 at 15 33 23](https://user-images.githubusercontent.com/6690098/161766328-e5f0f912-ee58-4023-ae53-6d2c756804a1.png)
Angular:
![Screenshot 2022-04-05 at 15 29 22](https://user-images.githubusercontent.com/6690098/161766349-5b4b74a3-069f-412e-8bdf-c4d1f23bc9c8.png)

