### PR TITLE
fix: Message overflow in thread & display command list above upload previews

### DIFF
--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -2,6 +2,14 @@
   display: block;
   position: relative;
 
+  /*
+  min-width in a flex context: While the default min-width value is 0, for flex items it is auto.
+  This can make block elements take up much more space than desired, resulting in overflow.
+   */
+  .str-chat__message-inner {
+    min-width: 0;
+  }
+
   .quoted-message {
     display: flex;
     align-items: flex-end;
@@ -1010,6 +1018,8 @@
       }
     }
   }
+
+
 }
 
 .livestream.str-chat {

--- a/src/styles/MessageInput.scss
+++ b/src/styles/MessageInput.scss
@@ -104,7 +104,7 @@
       box-shadow: 0 0 0 2px var(--primary-color-faded);
     }
 
-    &:placeholder {
+    &::placeholder {
       color: var(--black50);
     }
   }
@@ -117,7 +117,7 @@
   position: absolute;
   background: var(--white95);
   box-shadow: 0 0 1px 0 var(--black30), 0 0 6px 0 var(--black10);
-  z-index: -1;
+  z-index: 10001;
   border-radius: var(--border-radius-sm) var(--border-radius-sm) 0 0;
   margin: 0 var(--xs-m);
   max-height: 360px;


### PR DESCRIPTION
### 🎯 Goal

1. Provide a general css rule impacting all types of messages that would prevent messages' inner content to overflow from their message container.


2. Display the command list (Giphy) for message input above upload previews.

### 🛠 Implementation details

Message content overflowed in case of messages displaying uploaded file and in the past it was the case for the other message types too. Adding this rule should work for all the message types because the underlying problem is that the children of a flex container (`str-chat__message-simple`) have `min-width` value set by default to `auto`. This can make the block elements take up much more space than desired, resulting in overflow. Therefore the elements with class `str-chat__message-inner` get rule `min-width:0;`

Command list container got `z-index: 10001`. The system of z-indices should be reviewed in order to avoid getting to so high values for the rule (the close button on image preview has `z-index: 10000`).

### 🎨 UI Changes

#### Message overflow

Before:
![image](https://user-images.githubusercontent.com/32706194/161842009-03bba061-a100-48de-8af3-f710ed28065b.png)

After:
![image](https://user-images.githubusercontent.com/32706194/161842089-620a3838-2932-40e9-930c-4abcd8484b09.png)

#### Command list

Before:
![image](https://user-images.githubusercontent.com/32706194/161844413-93e8a0d5-689f-45c9-866a-ccde608194a7.png)


After:
![image](https://user-images.githubusercontent.com/32706194/161842812-4ada1d5e-c8ea-4c1d-a5b7-4f47fafe2126.png)

