### PR TITLE
fix: add missing dark theme styling for messaging app

### DIFF
--- a/src/styles/ActionsBox.scss
+++ b/src/styles/ActionsBox.scss
@@ -41,8 +41,8 @@
 
 .dark.str-chat {
   .str-chat__message-actions-box {
-    background: var(--grey);
-    background-image: linear-gradient(-180deg, var(--bg-gradient-start), var(--bg-gradient-end));
+    background: var(--dark-grey);
+    background-image: linear-gradient(-180deg, var(--dark-grey), var(--black20));
     box-shadow: 0 0 2px 0 var(--border), 0 1px 0 0 var(--border), 0 1px 8px 0 var(--border);
 
     button {

--- a/src/styles/ChannelList.scss
+++ b/src/styles/ChannelList.scss
@@ -17,6 +17,12 @@
   }
 }
 
+.dark.str-chat {
+  .str-chat__channel-list-messenger {
+    background: var(--dark-grey);
+  }
+}
+
 .str-chat__button {
   background: var(--white);
   box-shadow: 0 1px 1px 0 var(--black10), 0 1px 4px 0 var(--black10);

--- a/src/styles/ChannelSearch.scss
+++ b/src/styles/ChannelSearch.scss
@@ -102,10 +102,20 @@
 }
 
 .dark.str-chat {
-  .str-chat__channel-search {
+  .str-chat__channel-search,
+  .str-chat__channel-search-container.inline {
+    background: var(--dark-grey);
+    color: var(--white);
+
     input {
       background: var(--grey-gainsboro);
-      color: var(--white);
     }
+    .str-chat__channel-search-result {
+      color: var(--white);
+      &:hover {
+        background: var(--white5);
+      }
+    }
+
   }
 }

--- a/src/styles/ChannelSearch.scss
+++ b/src/styles/ChannelSearch.scss
@@ -110,12 +110,13 @@
     input {
       background: var(--grey-gainsboro);
     }
+
     .str-chat__channel-search-result {
       color: var(--white);
+
       &:hover {
         background: var(--white5);
       }
     }
-
   }
 }

--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -804,6 +804,12 @@
       }
     }
 
+    &--deleted-inner {
+        background: var(--dark-grey);
+        color: var(--white);
+    }
+
+
     &--me {
       .str-chat__message-simple-reply-button {
         display: flex;
@@ -1049,13 +1055,18 @@
 }
 
 .dark.str-chat {
+  .str-chat__message,
   .str-chat__message-simple {
     &-text-inner {
-      background: var(--white-smoke);
+      background: var(--dark-grey);
       color: var(--white);
 
       &--is-emoji {
         background: transparent;
+      }
+
+      .quoted-message-inner {
+        background: var(--dark-grey);
       }
     }
 
@@ -1074,17 +1085,22 @@
       background: transparent;
 
       &--content {
-        background: var(--white-smoke);
+        background: var(--dark-grey);
       }
 
       &--url {
         color: var(--grey-gainsboro);
       }
+
+      &--title {
+        color: var(--primary-color);
+      }
     }
 
     .str-chat__message-attachment--file {
       border-color: transparent;
-      background: var(--white-smoke);
+      background: var(--dark-grey);
+      color: var(--white10);
 
       a,
       span {
@@ -1102,25 +1118,35 @@
       }
     }
 
+    .str-chat__message-simple--deleted-inner,
+    .str-chat__message--deleted-inner {
+      background: var(--dark-grey);;
+      color: var(--white);
+    }
+
     &--me {
-      .str-chat__message-simple {
-        &-text-inner {
-          background: var(--black);
+      .str-chat__message-text-inner {
+        background: var(--black40);
 
-          &--is-emoji {
-            background: transparent;
-          }
+        &--is-emoji {
+          background: transparent;
         }
+      }
 
-        .str-chat__message-attachment-card {
-          &--content {
-            background: var(--black);
-          }
+      .str-chat__message-attachment-card {
+        &--content {
+          background: var(--black40);
         }
+      }
 
-        .str-chat__message-attachment--file {
-          background: var(--overlay);
-        }
+      .str-chat__message-attachment--file {
+        background: var(--black40);
+      }
+
+      .str-chat__message-simple--deleted-inner,
+      .str-chat__message--deleted-inner {
+        background: var(--black40);;
+        color: var(--white);
       }
     }
   }

--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -71,15 +71,13 @@
       &-attachment--img,
       &-attachment-card,
       .str-chat__gallery {
-        border-radius: var(--border-radius) var(--border-radius) var(--border-radius)
-          calc(var(--border-radius-sm) / 2);
+        border-radius: var(--border-radius) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
       }
 
       &.str-chat__message--has-text.str-chat__message--has-attachment {
         .str-chat__message-attachment--img,
         .str-chat__message-attachment-card {
-          border-radius: var(--border-radius) var(--border-radius) var(--border-radius)
-            calc(var(--border-radius-sm) / 2);
+          border-radius: var(--border-radius) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
         }
       }
 
@@ -88,28 +86,24 @@
         .str-chat__message {
           &-attachment--img,
           &-attachment-card {
-            border-radius: var(--border-radius) var(--border-radius)
-              calc(var(--border-radius-sm) / 2) var(--border-radius);
+            border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2) var(--border-radius);
           }
         }
 
         &.str-chat__message--has-text.str-chat__message--has-attachment {
           .str-chat__message-attachment--img,
           .str-chat__message-attachment-card {
-            border-radius: var(--border-radius) var(--border-radius)
-              calc(var(--border-radius-sm) / 2) var(--border-radius);
+            border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2) var(--border-radius);
           }
         }
 
         .str-chat__gallery {
-          border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2)
-            var(--border-radius);
+          border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2) var(--border-radius);
         }
 
         &.str-chat__message--has-text {
           .str-chat__gallery {
-            border-radius: var(--border-radius) var(--border-radius)
-              calc(var(--border-radius-sm) / 2) var(--border-radius);
+            border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2) var(--border-radius);
           }
         }
       }
@@ -123,16 +117,14 @@
       &-attachment--img,
       &-attachment-card,
       .str-chat__gallery {
-        border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius)
-          calc(var(--border-radius-sm) / 2);
+        border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
       }
 
       &.str-chat__message--has-text.str-chat__message--has-attachment {
         .str-chat__message-attachment--img,
         .str-chat__message-attachment-card,
         .str-chat__gallery {
-          border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius)
-            calc(var(--border-radius-sm) / 2);
+          border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
         }
       }
 
@@ -141,8 +133,7 @@
           &-attachment--img,
           &-attachment-card,
           .str-chat__gallery {
-            border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2)
-              calc(var(--border-radius-sm) / 2) var(--border-radius);
+            border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2) calc(var(--border-radius-sm) / 2) var(--border-radius);
           }
         }
 
@@ -164,16 +155,14 @@
       &-attachment--img,
       &-attachment-card,
       .str-chat__gallery {
-        border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius)
-          calc(var(--border-radius-sm) / 2);
+        border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
       }
 
       &.str-chat__message--has-text.str-chat__message--has-attachment {
         .str-chat__message-attachment--img,
         .str-chat__message-attachment-card,
         .str-chat__gallery {
-          border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius)
-            calc(var(--border-radius-sm) / 2);
+          border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
         }
       }
 
@@ -182,8 +171,7 @@
           &-attachment--img,
           &-attachment-card,
           .str-chat__gallery {
-            border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2)
-              calc(var(--border-radius-sm) / 2) var(--border-radius);
+            border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2) calc(var(--border-radius-sm) / 2) var(--border-radius);
           }
         }
 
@@ -215,16 +203,14 @@
     .str-chat__message {
       &-text {
         &-inner {
-          border-radius: var(--border-radius) var(--border-radius) var(--border-radius)
-            calc(var(--border-radius-sm) / 2);
+          border-radius: var(--border-radius) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
         }
       }
 
       &--me {
         .str-chat__message-text {
           &-inner {
-            border-radius: var(--border-radius) var(--border-radius)
-              calc(var(--border-radius-sm) / 2) var(--border-radius);
+            border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2) var(--border-radius);
           }
         }
       }
@@ -235,12 +221,10 @@
     .str-chat__message {
       &-text {
         &-inner {
-          border-radius: var(--border-radius) var(--border-radius) var(--border-radius)
-            calc(var(--border-radius-sm) / 2);
+          border-radius: var(--border-radius) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
 
           &--has-attachment {
-            border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius)
-              var(--border-radius) calc(var(--border-radius-sm) / 2);
+            border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
           }
         }
       }
@@ -248,12 +232,10 @@
       &--me {
         .str-chat__message-text {
           &-inner {
-            border-radius: var(--border-radius) var(--border-radius)
-              calc(var(--border-radius-sm) / 2) var(--border-radius);
+            border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2) var(--border-radius);
 
             &--has-attachment {
-              border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2)
-                calc(var(--border-radius-sm) / 2) var(--border-radius);
+              border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2) calc(var(--border-radius-sm) / 2) var(--border-radius);
             }
           }
         }
@@ -266,16 +248,14 @@
     .str-chat__message {
       &-text {
         &-inner {
-          border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius)
-            calc(var(--border-radius-sm) / 2);
+          border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
         }
       }
 
       &--me {
         .str-chat__message-text {
           &-inner {
-            border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2)
-              calc(var(--border-radius-sm) / 2) var(--border-radius);
+            border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2) calc(var(--border-radius-sm) / 2) var(--border-radius);
 
             &--has-attachment {
               margin: 0;
@@ -286,8 +266,7 @@
         .str-chat__message-attachment-card {
           margin: 0;
           padding: 0;
-          border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2)
-            calc(var(--border-radius-sm) / 2) var(--border-radius);
+          border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2) calc(var(--border-radius-sm) / 2) var(--border-radius);
         }
       }
     }
@@ -408,8 +387,7 @@
       }
 
       &--has-attachment {
-        border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius)
-          calc(var(--border-radius-sm) / 2);
+        border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
       }
 
       /* if text consists of just one emoji */
@@ -499,8 +477,7 @@
         background: var(--grey-whisper);
         border-color: transparent;
         text-align: right;
-        border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2)
-          var(--border-radius);
+        border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2) var(--border-radius);
         margin-right: 0; /* set spacing when unfocused */
 
         &--focused {
@@ -511,8 +488,7 @@
         }
 
         &--has-attachment {
-          border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2)
-            calc(var(--border-radius-sm) / 2) var(--border-radius);
+          border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2) calc(var(--border-radius-sm) / 2) var(--border-radius);
         }
 
         &--is-emoji {
@@ -625,7 +601,9 @@
               }
             }
           }
-        } /* __li*/
+        }
+
+        /* __li*/
       }
     }
   }
@@ -805,8 +783,8 @@
     }
 
     &--deleted-inner {
-        background: var(--dark-grey);
-        color: var(--white);
+      background: var(--dark-grey);
+      color: var(--white);
     }
 
 
@@ -978,8 +956,7 @@
       &:first-of-type {
         border-bottom: 1px solid var(--grey-gainsboro);
         border-top: 1px solid var(--grey-gainsboro);
-        border-radius: var(--border-radius) var(--border-radius) var(--border-radius)
-          calc(var(--border-radius-sm) / 2);
+        border-radius: var(--border-radius) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
       }
     }
   }
@@ -990,8 +967,7 @@
 
   &--me {
     .str-chat__message-attachment-card {
-      border-radius: var(--border-radius) var(--border-radius-sm) var(--border-radius-sm)
-        var(--border-radius-sm);
+      border-radius: var(--border-radius) var(--border-radius-sm) var(--border-radius-sm) var(--border-radius-sm);
     }
 
     .str-chat__message-attachment--file {
@@ -1001,8 +977,7 @@
         border-radius: 0 0 calc(var(--border-radius-sm) / 2) var(--border-radius);
 
         &:first-of-type:not(.str-chat-angular__message-attachment-file-single) {
-          border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2)
-            var(--border-radius);
+          border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2) var(--border-radius);
         }
       }
     }
@@ -1019,8 +994,7 @@
       .str-chat__message-actions-box {
         right: unset;
         left: 100%;
-        border-radius: var(--border-radius) var(--border-radius) var(--border-radius)
-          calc(var(--border-radius-sm) / 2);
+        border-radius: var(--border-radius) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
       }
     }
   }
@@ -1120,7 +1094,7 @@
 
     .str-chat__message-simple--deleted-inner,
     .str-chat__message--deleted-inner {
-      background: var(--dark-grey);;
+      background: var(--dark-grey);
       color: var(--white);
     }
 
@@ -1145,7 +1119,7 @@
 
       .str-chat__message-simple--deleted-inner,
       .str-chat__message--deleted-inner {
-        background: var(--black40);;
+        background: var(--black40);
         color: var(--white);
       }
     }
@@ -1178,22 +1152,19 @@
       &--reverse {
         right: 100%;
         left: unset;
-        border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2)
-          var(--border-radius);
+        border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2) var(--border-radius);
       }
     }
 
     .str-chat__message-actions-box--mine {
       right: 100%;
       left: unset;
-      border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2)
-        var(--border-radius);
+      border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2) var(--border-radius);
 
       &.str-chat__message-actions-box--reverse {
         left: 100%;
         right: unset;
-        border-radius: var(--border-radius) var(--border-radius) var(--border-radius)
-          calc(var(--border-radius-sm) / 2);
+        border-radius: var(--border-radius) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
       }
     }
   }

--- a/src/styles/MessageInput.scss
+++ b/src/styles/MessageInput.scss
@@ -82,6 +82,12 @@
   }
 }
 
+.dark .str-chat__textarea {
+  textarea::placeholder {
+    color: var(--white30);
+  }
+}
+
 .str-chat__textarea {
   height: auto;
   flex: 1;

--- a/src/styles/MessageInputFlat.scss
+++ b/src/styles/MessageInputFlat.scss
@@ -289,6 +289,10 @@
         fill: var(--white);
       }
     }
+
+    &-quoted .quoted-message-preview-content {
+      background: var(--black20);
+    }
   }
 
   &.commerce {

--- a/src/styles/Thread.scss
+++ b/src/styles/Thread.scss
@@ -206,7 +206,8 @@
         background: var(--white5);
 
         &-header {
-          background: var(--black80);
+          background: var(--dark-grey);
+
           box-shadow: 0 7px 9px 0 var(--black5), 0 1px 0 0 var(--black5);
           color: var(--white);
         }
@@ -305,6 +306,14 @@
         border-radius: var(--border-radius-sm);
         color: var(--white);
       }
+    }
+  }
+}
+
+.dark.str-chat.messaging {
+  .str-chat__thread-list {
+    .quoted-message-inner {
+      background: var(--dark-grey);
     }
   }
 }

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -49,6 +49,10 @@
   font-family: var(--second-font);
   color: var(--black);
 
+  &.dark {
+    color: var(--white);
+  }
+
   &.messaging,
   &.commerce {
     background-color: var(--grey-gainsboro);


### PR DESCRIPTION
### 🎯 Goal

Add missing dark theme styles to basic chat components. Allow to reuse those styles in website-react-examples demo apps.


### 🎨 UI Changes

![image](https://user-images.githubusercontent.com/32706194/162070710-94e09ac4-1eb9-4e5c-af19-e8d7c96f72ce.png)

![image](https://user-images.githubusercontent.com/32706194/162070884-da35c492-6c7a-4b50-8a30-756d8bc0c7cc.png)

![image](https://user-images.githubusercontent.com/32706194/162070954-eeeaad6a-35b9-425e-8a73-24941e53c698.png)

