### PR TITLE
fix: prevent video from overflowing or having no width

### DIFF
--- a/src/styles/Attachment.scss
+++ b/src/styles/Attachment.scss
@@ -166,7 +166,7 @@
   }
 
   &--media {
-    max-width: 300px;
+    width: 300px;
   }
 
   &-card {

--- a/src/styles/Thread.scss
+++ b/src/styles/Thread.scss
@@ -61,11 +61,18 @@
     .str-chat__message:first-of-type .str-chat__message-inner {
       margin-left: unset;
       margin-right: unset;
+      width: 100%;
     }
 
-    .str-chat__message-attachment.str-chat__message-attachment--file {
-      border-radius: var(--border-radius-md);
-      border-bottom: 1px solid var(--grey-whisper);
+    .str-chat__message-attachment.str-chat__message-attachment {
+      &--file {
+        border-radius: var(--border-radius-md);
+        border-bottom: 1px solid var(--grey-whisper);
+      }
+
+      &--media {
+        width: 100%;
+      }
     }
 
     .quoted-message {


### PR DESCRIPTION
### 🎯 Goal

1. Fix regression bug that reduced video width in both MessageList and Thread to 0. The media width was set back to `width: 300px` instead of `max-width: 300px`.
2. Prevent videos from overflowing in thread.

### 🎨 UI Changes

![image](https://user-images.githubusercontent.com/32706194/163185213-caf07049-3121-4f2d-bb52-63db63794a8a.png)
