### PR TITLE
Channel and header

### DIFF
--- a/docs/theming/component-variables.mdx
+++ b/docs/theming/component-variables.mdx
@@ -45,7 +45,7 @@ Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/style
 | Name                                                           | Description                                                              |
 | -------------------------------------------------------------- | ------------------------------------------------------------------------ |
 | `--str-chat__channel-preview-font-family`                      | The font used in the component                                           |
-| `--str-chat__channel-preview-color`                            | The text/icon color of the the component                                 |
+| `--str-chat__channel-preview-color`                            | The text/icon color of the component                                     |
 | `--str-chat__channel-preview-background-color`                 | The background color of the component                                    |
 | `--str-chat__channel-preview-border-radius`                    | The border radius used for the borders of the component                  |
 | `--str-chat__channel-preview-border-block-start`               | Top border of the component                                              |
@@ -65,12 +65,102 @@ Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/style
 
 Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/ChannelPreview/ChannelPreview-theme.scss](https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/ChannelPreview/ChannelPreview-theme.scss)
 
+## Channel
+
+| Name                                        | Description                                             |
+| ------------------------------------------- | ------------------------------------------------------- |
+| `--str-chat__channel-font-family`           | The font used in the component                          |
+| `--str-chat__channel-color`                 | The text/icon color of the component                    |
+| `--str-chat__channel-background-color`      | The background color of the component                   |
+| `--str-chat__channel-border-radius`         | The border radius used for the borders of the component |
+| `--str-chat__channel-border-block-start`    | Top border of the component                             |
+| `--str-chat__channel-border-block-end`      | Bottom border of the component                          |
+| `--str-chat__channel-border-inline-start`   | Left (right in RTL layout) border of the component      |
+| `--str-chat__channel-border-inline-start`   | Right (lrft in RTL layout) border of the component      |
+| `--str-chat__channel-box-shadow`            | Box shadow applied to the component                     |
+| `--str-chat__channel-empty-indicator-color` | The icon color used when no channel is selected         |
+| `--str-chat__channel-empty-color`           | The text color used when no channel is selected         |
+| `--str-chat__channel-loading-state-color`   | The color of the loading indicator                      |
+
+Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/Channel/Channel-theme.scss](https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/Channel/Channel-theme.scss)
+
+## Channel header
+
+| Name                                             | Description                                                              |
+| ------------------------------------------------ | ------------------------------------------------------------------------ |
+| `--str-chat__channel-header-font-family`         | The font used in the component                                           |
+| `--str-chat__channel-header-color`               | The text/icon color of the component                                     |
+| `--str-chat__channel-header-background-color`    | The background color of the component                                    |
+| `--str-chat__channel-header-border-radius`       | The border radius used for the borders of the component                  |
+| `--str-chat__channel-header-border-block-start`  | Top border of the component                                              |
+| `--str-chat__channel-header-border-block-end`    | Bottom border of the component                                           |
+| `--str-chat__channel-header-border-inline-start` | Left (right in RTL layout) border of the component                       |
+| `--str-chat__channel-header-border-inline-start` | Right (lrft in RTL layout) border of the component                       |
+| `--str-chat__channel-header-box-shadow`          | Box shadow applied to the component                                      |
+| `--str-chat__channel-header-info-color`          | The text/icon color used to display member information about the channel |
+
+Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/ChannelHeader/ChannelHeader-theme.scss](https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/ChannelHeader/ChannelHeader-theme.scss)
+
+## Message list
+
+| Name                                                               | Description                                                                            |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `--str-chat__message-list-font-family`                             | The font used in the component                                                         |
+| `--str-chat__message-list-color`                                   | The text/icon color of the component                                                   |
+| `--str-chat__message-list-background-color`                        | The background color of the component                                                  |
+| `--str-chat__message-list-border-radius`                           | The border radius used for the borders of the component                                |
+| `--str-chat__message-list-border-block-start`                      | Top border of the component                                                            |
+| `--str-chat__message-list-border-block-end`                        | Bottom border of the component                                                         |
+| `--str-chat__message-list-inline-start`                            | Left (right in RTL layout) border of the component                                     |
+| `--str-chat__message-list-border-inline-start`                     | Right (lrft in RTL layout) border of the component                                     |
+| `--str-chat__message-list-box-shadow`                              | Box shadow applied to the component                                                    |
+| `--str-chat__jump-to-latest-message-font-family`                   | The font used in the jump to latest message button                                     |
+| `--str-chat__jump-to-latest-message-color`                         | The text/icon color of the jump to latest message button                               |
+| `--str-chat__jump-to-latest-message-background-color`              | The background color of the jump to latest message button                              |
+| `--str-chat__jump-to-latest-message-pressed-background-color`      | The background color of the jump to latest message button in pressed state             |
+| `--str-chat__jump-to-latest-message-border-radius`                 | The border radius used for the borders of the jump to latest message button            |
+| `--str-chat__jump-to-latest-message-border-block-start`            | Top border of the jump to latest message button                                        |
+| `--str-chat__jump-to-latest-message-border-block-end`              | Bottom border of the jump to latest message button                                     |
+| `--str-chat__jump-to-latest-message-inline-start`                  | Left (right in RTL layout) border of the jump to latest message button                 |
+| `--str-chat__jump-to-latest-message-border-inline-start`           | Right (lrft in RTL layout) border of the jump to latest message button                 |
+| `--str-chat__jump-to-latest-message-box-shadow`                    | Box shadow applied to the jump to latest message button                                |
+| `--str-chat__jump-to-latest-message-unread-count-color`            | The text/icon color of the unread messages count on the jump to latest message button  |
+| `--str-chat__jump-to-latest-message-unread-count-background-color` | The background color of the unread messages count on the jump to latest message button |
+
+Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/MessageList/MessageList-theme.scss](https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/MessageList/CMessageList-theme.scss)
+
+## Thread
+
+| Name                                            | Description                                                                    |
+| ----------------------------------------------- | ------------------------------------------------------------------------------ |
+| `--str-chat__thread-font-family`                | The font used in the component                                                 |
+| `--str-chat__thread-color`                      | The text/icon color of the component                                           |
+| `--str-chat__thread-background-color`           | The background color of the component                                          |
+| `--str-chat__thread-border-radius`              | The border radius used for the borders of the component                        |
+| `--str-chat__thread-border-block-start`         | Top border of the component                                                    |
+| `--str-chat__thread-border-block-end`           | Bottom border of the component                                                 |
+| `--str-chat__thread-border-inline-start`        | Left (right in RTL layout) border of the component                             |
+| `--str-chat__thread-border-inline-start`        | Right (lrft in RTL layout) border of the component                             |
+| `--str-chat__thread-box-shadow`                 | Box shadow applied to the component                                            |
+| `--str-chat__thread-empty-indicator-color`      | The icon color used when no channel is selected                                |
+| `--str-chat__thread-empty-color`                | The text color used when no channel is selected                                |
+| `--str-chat__thread-header-font-family`         | The font used in the thread header                                             |
+| `--str-chat__thread-header-color`               | The text/icon color of the thread header                                       |
+| `--str-chat__thread-header-background-color`    | The background color of the thread header                                      |
+| `--str-chat__thread-header-border-radius`       | The border radius used for the borders of the thread header                    |
+| `--str-chat__thread-header-border-block-start`  | Top border of the thread header                                                |
+| `--str-chat__thread-header-border-block-end`    | Bottom border of the thread header                                             |
+| `--str-chat__thread-header-border-inline-start` | Left (right in RTL layout) border of the thread header                         |
+| `--str-chat__thread-header-border-inline-start` | Right (lrft in RTL layout) border of the thread header                         |
+| `--str-chat__thread-header-box-shadow`          | Box shadow applied to the thread header                                        |
+| `--str-chat__thread-header-info-color`          | The text/icon color used to display less emphasized text in the channel header |
+
 ## Avatar
 
 | Name                                     | Description                                             |
 | ---------------------------------------- | ------------------------------------------------------- |
 | `--str-chat__avatar-font-family`         | The font used in the component                          |
-| `--str-chat__avatar-color`               | The text/icon color of the the component                |
+| `--str-chat__avatar-color`               | The text/icon color of the component                    |
 | `--str-chat__avatar-background-color`    | The background color of the component                   |
 | `--str-chat__avatar-border-radius`       | The border radius used for the borders of the component |
 | `--str-chat__avatar-border-block-start`  | Top border of the component                             |
@@ -91,7 +181,7 @@ Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/style
 
 This is a generic component used to display action buttons.
 
-Call-to-actions buttons: channel list load more button
+Call-to-actions buttons on the chat UI: channel list load more button
 
 You can override the following variables if you want to adjust the style of all call-to-action buttons in the chat UI
 
@@ -111,3 +201,26 @@ You can override the following variables if you want to adjust the style of all 
 | `--str-chat__cta-button-disabled-color`            | The text/icon color of the button in disabled state  |
 
 Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/common/CTAButton/CTAButton-theme.scss](https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/common/CTAButton/CTAButton-theme.scss)
+
+## Circle floating action button
+
+This is a generic component used to display floating action buttons.
+
+Floating action buttons on the chat UI: jump to the latest messages button.
+
+You can override the following variables if you want to adjust the style of all floating action buttons in the chat UI
+
+| Name                                              | Description                                          |
+| ------------------------------------------------- | ---------------------------------------------------- |
+| `--str-chat__circle-fab-font-family`              | The font used for the button                         |
+| `--str-chat__circle-fab-color`                    | The text/icon color of the button                    |
+| `--str-chat__circle-fab-background-color`         | The background color of the button                   |
+| `--str-chat__circle-fab-border-radius`            | The border radius used for the borders of the button |
+| `--str-chat__circle-fab-border-block-start`       | Top border of the button                             |
+| `--str-chat__circle-fab-border-block-end`         | Bottom border of the button                          |
+| `--str-chat__circle-fab-border-inline-start`      | Left (right in RTL layout) border of the button      |
+| `--str-chat__circle-fab-border-inline-start`      | Right (lrft in RTL layout) border of the button      |
+| `--str-chat__circle-fab-more-box-shadow`          | Box shadow applied to the button                     |
+| `--str-chat__circle-fab-pressed-background-color` | The background color of the button in pressed state  |
+
+Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/common/CircleFAButton/CircleFAButton-theme.scss](https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/common/CircleFAButton/CircleFAButton-theme.scss)

--- a/src-v2/styles/Channel/Channel-layout.scss
+++ b/src-v2/styles/Channel/Channel-layout.scss
@@ -1,0 +1,132 @@
+@use '../utils';
+
+.str-chat__channel {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  .str-chat__container {
+    height: 100%;
+    display: flex;
+    flex-direction: row;
+
+    .str-chat__main-panel {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+    }
+  }
+}
+
+.str-chat__empty-channel {
+  @include utils.empty-layout;
+}
+
+.str-chat__loading-channel {
+  $text-height: calc(var(--str-chat__spacing-px) * 16);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  .str-chat__loading-channel-header {
+    @include utils.header-layout;
+
+    .str-chat__loading-channel-header-avatar {
+      flex-shrink: 0;
+      width: calc(var(--str-chat__spacing-px) * 40);
+      height: calc(var(--str-chat__spacing-px) * 40);
+      border-radius: var(--str-chat__avatar-border-radius);
+    }
+
+    .str-chat__loading-channel-header-end {
+      @include utils.header-text-layout;
+
+      .str-chat__loading-channel-header-name {
+        border-radius: var(--str-chat__border-radius-xs);
+        height: $text-height;
+        width: calc(var(--str-chat__spacing-px) * 170);
+      }
+
+      .str-chat__loading-channel-header-info {
+        border-radius: var(--str-chat__border-radius-xs);
+        height: $text-height;
+        width: calc(var(--str-chat__spacing-px) * 66);
+      }
+    }
+  }
+
+  .str-chat__loading-channel-message-list {
+    @include utils.message-list-spacing;
+    height: 100%;
+
+    .str-chat__loading-channel-message {
+      display: flex;
+      width: 100%;
+      column-gap: var(--str-chat__spacing-2);
+      padding: var(--str-chat__spacing-4) 0;
+
+      .str-chat__loading-channel-message-avatar {
+        flex-shrink: 0;
+        width: calc(var(--str-chat__spacing-px) * 49);
+        height: calc(var(--str-chat__spacing-px) * 49);
+      }
+
+      .str-chat__loading-channel-message-end {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        row-gap: var(--str-chat__spacing-2);
+
+        .str-chat__loading-channel-message-last-row {
+          display: flex;
+          width: 100%;
+          column-gap: var(--str-chat__spacing-2);
+        }
+      }
+
+      .str-chat__loading-channel-message-sender {
+        height: $text-height;
+        width: calc(var(--str-chat__spacing-px) * 66);
+      }
+
+      .str-chat__loading-channel-message-text {
+        height: $text-height;
+        width: 100%;
+      }
+
+      .str-chat__loading-channel-message-date {
+        height: $text-height;
+        width: calc(var(--str-chat__spacing-px) * 50);
+      }
+
+      &:nth-of-type(2) {
+        flex-direction: row-reverse;
+
+        .str-chat__loading-channel-message-sender {
+          align-self: end;
+        }
+
+        .str-chat__loading-channel-message-last-row {
+          flex-direction: row-reverse;
+        }
+      }
+    }
+  }
+
+  .str-chat__loading-channel-message-input-row {
+    display: flex;
+    column-gap: var(--str-chat__spacing-2);
+    padding: var(--str-chat__spacing-2);
+
+    .str-chat__loading-channel-message-input {
+      width: 100%;
+      height: calc(var(--str-chat__spacing-px) * 36);
+    }
+
+    .str-chat__loading-channel-message-send {
+      height: calc(var(--str-chat__spacing-px) * 36);
+      width: calc(var(--str-chat__spacing-px) * 36);
+    }
+  }
+}

--- a/src-v2/styles/Channel/Channel-theme.scss
+++ b/src-v2/styles/Channel/Channel-theme.scss
@@ -1,0 +1,68 @@
+@use '../utils';
+
+.str-chat {
+  --str-chat__channel-font-family: var(--str-chat__font-family);
+  --str-chat__channel-border-radius: 0;
+  --str-chat__channel-color: var(--str-chat__text-color);
+  --str-chat__channel-background-color: var(--str-chat__background-color);
+  --str-chat__channel-box-shadow: none;
+  --str-chat__channel-border-block-start: none;
+  --str-chat__channel-border-block-end: none;
+  --str-chat__channel-border-inline-start: none;
+  --str-chat__channel-border-inline-end: none;
+  --str-chat__channel-empty-indicator-color: var(--str-chat__disabled-color);
+  --str-chat__channel-empty-color: var(--str-chat__text-low-emphasis-color);
+  --str-chat__channel-loading-state-color: var(--str-chat__disabled-color);
+}
+
+.str-chat__channel {
+  @include utils.component-layer-overrides('channel');
+}
+
+.str-chat__empty-channel {
+  @include utils.component-layer-overrides('channel');
+  @include utils.empty-theme('channel');
+
+  .str-chat__empty-channel-text {
+    color: var(--str-chat__channel-empty-color);
+  }
+}
+
+.str-chat__loading-channel {
+  @include utils.loading-animation;
+
+  .str-chat__loading-channel-header {
+    background-color: var(--str-chat__channel-header-background-color);
+
+    .str-chat__loading-channel-header-avatar {
+      @include utils.loading-item-background('channel');
+      border-radius: var(--str-chat__avatar-border-radius);
+    }
+
+    .str-chat__loading-channel-header-name,
+    .str-chat__loading-channel-header-info {
+      @include utils.loading-item-background('channel');
+      border-radius: var(--str-chat__border-radius-xs);
+    }
+  }
+
+  .str-chat__loading-channel-message-list {
+    background-color: var(--str-chat__message-list-background-color);
+
+    .str-chat__loading-channel-message-avatar,
+    .str-chat__loading-channel-message-sender,
+    .str-chat__loading-channel-message-text,
+    .str-chat__loading-channel-message-date {
+      @include utils.loading-item-background('channel');
+      border-radius: var(--str-chat__avatar-border-radius);
+    }
+  }
+
+  .str-chat__loading-channel-message-input-row {
+    .str-chat__loading-channel-message-input,
+    .str-chat__loading-channel-message-send {
+      @include utils.loading-item-background('channel');
+      border-radius: var(--str-chat__border-radius-circle);
+    }
+  }
+}

--- a/src-v2/styles/ChannelHeader/ChannelHeader-layout.scss
+++ b/src-v2/styles/ChannelHeader/ChannelHeader-layout.scss
@@ -1,0 +1,23 @@
+@use '../utils';
+
+.str-chat__channel-header {
+  @include utils.header-layout;
+
+  // Only visible in theme-v1
+  .str-chat__header-hamburger {
+    display: none;
+  }
+
+  .str-chat__channel-header-end {
+    @include utils.header-text-layout;
+
+    p {
+      margin: 0;
+    }
+
+    .str-chat__channel-header-title,
+    .str-chat__channel-header-info {
+      @include utils.ellipsis-text;
+    }
+  }
+}

--- a/src-v2/styles/ChannelHeader/ChannelHeader-theme.scss
+++ b/src-v2/styles/ChannelHeader/ChannelHeader-theme.scss
@@ -1,0 +1,31 @@
+@use '../utils';
+
+.str-chat {
+  --str-chat__channel-header-font-family: var(--str-chat__font-family);
+  --str-chat__channel-header-border-radius: 0;
+  --str-chat__channel-header-color: 0;
+  --str-chat__channel-header-background-color: var(--str-chat__secondary-background-color);
+  --str-chat__channel-header-border-block-start: none;
+  --str-chat__channel-header-border-block-end: none;
+  --str-chat__channel-header-border-inline-start: none;
+  --str-chat__channel-header-border-inline-end: none;
+  --str-chat__channel-header-box-shadow: none;
+  --str-chat__channel-header-info-color: var(--str-chat__text-low-emphasis-color);
+}
+
+.str-chat__channel-header {
+  @include utils.component-layer-overrides('channel-header');
+
+  .str-chat__channel-header-title {
+    font-size: 1rem;
+    line-height: 1.25rem;
+    font-weight: 500;
+  }
+
+  .str-chat__channel-header-info {
+    font-size: 0.875rem;
+    line-height: 1rem;
+    color: var(--str-chat__channel-header-info-color);
+    font-weight: 400;
+  }
+}

--- a/src-v2/styles/ChannelList/ChannelList-layout.scss
+++ b/src-v2/styles/ChannelList/ChannelList-layout.scss
@@ -1,6 +1,9 @@
+@use '../utils';
+
 .str-chat__channel-list {
   height: 100%;
   overflow-y: auto;
+  overflow-x: hidden;
 
   .str-chat__channel-list-messenger {
     height: 100%;
@@ -9,17 +12,7 @@
       height: 100%;
 
       .str-chat__channel-list-empty {
-        height: 100%;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        padding: var(--str-chat__spacing-4);
-
-        svg {
-          width: calc(var(--str-chat__spacing-px) * 136);
-          height: calc(var(--str-chat__spacing-px) * 136);
-        }
+        @include utils.empty-layout;
       }
 
       // Empty channel list for theme-v1

--- a/src-v2/styles/ChannelList/ChannelList-theme.scss
+++ b/src-v2/styles/ChannelList/ChannelList-theme.scss
@@ -46,12 +46,6 @@
   }
 
   .str-chat__channel-list-empty {
-    font-size: 1.5rem;
-    line-height: 1.5rem;
-    text-align: center;
-
-    svg path {
-      fill: var(--str-chat__channel-list-empty-indicator-color);
-    }
+    @include utils.empty-theme('channel-list');
   }
 }

--- a/src-v2/styles/ChannelPreview/ChannelPreview-layout.scss
+++ b/src-v2/styles/ChannelPreview/ChannelPreview-layout.scss
@@ -26,6 +26,13 @@
   }
 }
 
+// Unread badge will be bigger than channel name -> this would cause a layout shift when the unread badge appears -> this trick won't let the unread badge to increase the height of the container avoiding the layout shift
+@mixin unread-badge-layout-fix {
+  .str-chat__channel-preview-end-first-row {
+    height: var(--str-chat__unread-badge-height);
+  }
+}
+
 .str-chat__channel-preview {
   @include channel-preview-layout;
   cursor: pointer;

--- a/src-v2/styles/ChannelPreview/ChannelPreview-theme.scss
+++ b/src-v2/styles/ChannelPreview/ChannelPreview-theme.scss
@@ -70,34 +70,12 @@
 }
 
 .str-chat__channel-preview-loading {
-  animation: pulsate 1s linear 0s infinite alternate;
-
-  &:nth-of-type(2) {
-    animation: pulsate 1s linear 0.3334 infinite alternate;
-  }
-
-  &:last-of-type {
-    animation: pulsate 1s linear 0.6667s infinite alternate;
-  }
-
-  @keyframes pulsate {
-    from {
-      opacity: 0.5;
-    }
-
-    to {
-      opacity: 1;
-    }
-  }
+  @include utils.loading-animation;
 
   .str-chat__loading-channels-avatar,
   .str-chat__loading-channels-username,
   .str-chat__loading-channels-status {
-    background-image: linear-gradient(
-      -90deg,
-      var(--str-chat__channel-preview-loading-state-color) 0%,
-      var(--str-chat__channel-preview-loading-state-color) 100%
-    );
+    @include utils.loading-item-background('channel-preview');
   }
 
   .str-chat__loading-channels-username,

--- a/src-v2/styles/MessageList/MessageList-layout.scss
+++ b/src-v2/styles/MessageList/MessageList-layout.scss
@@ -1,0 +1,35 @@
+@use '../utils';
+
+.str-chat__main-panel-inner {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  position: relative;
+  align-items: center;
+
+  .str-chat__list {
+    width: 100%;
+    height: 100%;
+    max-height: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+
+    .str-chat__message-list-scroll {
+      @include utils.message-list-spacing;
+    }
+  }
+}
+
+.str-chat__jump-to-latest-message {
+  position: absolute;
+  inset-block-end: var(--str-chat__spacing-4);
+  inset-inline-end: var(--str-chat__spacing-2);
+
+  .str-chat__jump-to-latest-unread-count {
+    position: absolute;
+    padding: var(--str-chat__spacing-1) var(--str-chat__spacing-2);
+    left: 50%;
+    transform: translateX(-50%) translateY(-100%);
+  }
+}

--- a/src-v2/styles/MessageList/MessageList-theme.scss
+++ b/src-v2/styles/MessageList/MessageList-theme.scss
@@ -1,0 +1,55 @@
+@use '../utils';
+
+.str-chat {
+  --str-chat__message-list-font-family: var(--str-chat__font-family);
+  --str-chat__message-list-border-radius: 0;
+  --str-chat__message-list-color: var(--str-chat__text-color);
+  --str-chat__message-list-background-color: var(--str-chat__background-color);
+  --str-chat__message-list-box-shadow: none;
+  --str-chat__message-list-border-block-start: none;
+  --str-chat__message-list-border-block-end: none;
+  --str-chat__message-list-border-inline-start: none;
+  --str-chat__message-list-border-inline-end: none;
+  --str-chat__jump-to-latest-message-font-family: var(--str-chat__circle-fab-font-family);
+  --str-chat__jump-to-latest-message-border-radius: var(--str-chat__circle-fab-border-radius);
+  --str-chat__jump-to-latest-message-color: var(--str-chat__circle-fab-color);
+  --str-chat__jump-to-latest-message-background-color: var(--str-chat__circle-fab-background-color);
+  --str-chat__jump-to-latest-message-pressed-background-color: var(
+    --str-chat__circle-fab-pressed-background-color
+  );
+  --str-chat__jump-to-latest-message-box-shadow: var(--str-chat__circle-fab-box-shadow);
+  --str-chat__jump-to-latest-message-border-block-start: var(
+    --str-chat__circle-fab-border-block-start
+  );
+  --str-chat__jump-to-latest-message-border-block-end: var(--str-chat__circle-fab-border-block-end);
+  --str-chat__jump-to-latest-message-border-inline-start: var(
+    --str-chat__circle-fab-border-inline-start
+  );
+  --str-chat__jump-to-latest-message-border-inline-end: var(
+    --str-chat__circle-fab-border-inline-end
+  );
+  --str-chat__jump-to-latest-message-unread-count-background-color: var(
+    --str-chat__jump-to-latest-message-color
+  );
+  --str-chat__jump-to-latest-message-unread-count-color: var(
+    --str-chat__jump-to-latest-message-background-color
+  );
+}
+
+.str-chat__list {
+  @include utils.component-layer-overrides('message-list');
+}
+
+.str-chat__jump-to-latest-message {
+  .str-chat__circle-fab {
+    @include utils.component-layer-overrides('jump-to-latest-message');
+    @include utils.circle-fab-overrides('jump-to-latest-message');
+
+    .str-chat__jump-to-latest-unread-count {
+      background-color: var(--str-chat__jump-to-latest-message-unread-count-background-color);
+      color: var(--str-chat__jump-to-latest-message-unread-count-color);
+      border-radius: var(--str-chat__jump-to-latest-message-border-radius);
+      font-size: 0.625rem;
+    }
+  }
+}

--- a/src-v2/styles/Thread/Thread-layout.scss
+++ b/src-v2/styles/Thread/Thread-layout.scss
@@ -1,0 +1,35 @@
+@use '../utils';
+
+.str-chat__thread-container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+
+  .str-chat__thread-header {
+    @include utils.header-layout;
+
+    .str-chat__thread-header-details {
+      @include utils.header-text-layout;
+
+      .str-chat__thread-header-name,
+      .str-chat__thread-header-reply-count {
+        @include utils.ellipsis-text;
+      }
+    }
+
+    .str-chat__close-thread-button {
+      $icon-size: calc(var(--str-chat__spacing-px) * 21);
+      width: calc(var(--str-chat__spacing-px) * 40);
+      height: calc(var(--str-chat__spacing-px) * 40);
+      cursor: pointer;
+      line-height: $icon-size;
+      font-size: $icon-size;
+
+      svg {
+        height: $icon-size;
+        width: $icon-size;
+      }
+    }
+  }
+}

--- a/src-v2/styles/Thread/Thread-theme.scss
+++ b/src-v2/styles/Thread/Thread-theme.scss
@@ -1,0 +1,54 @@
+@use '../utils';
+
+.str-chat {
+  --str-chat__thread-font-family: var(--str-chat__font-family);
+  --str-chat__thread-border-radius: 0;
+  --str-chat__thread-color: var(--str-chat__text-color);
+  --str-chat__thread-background-color: var(--str-chat__background-color);
+  --str-chat__thread-border-block-start: none;
+  --str-chat__thread-border-block-end: none;
+  --str-chat__thread-border-inline-start: 1px solid var(--str-chat__surface-color);
+  --str-chat__thread-border-inline-end: none;
+  --str-chat__thread-box-shadow: none;
+
+  --str-chat__thread-header-font-family: var(--str-chat__font-family);
+  --str-chat__thread-header-border-radius: 0;
+  --str-chat__thread-header-color: var(--str-chat__text-color);
+  --str-chat__thread-header-background-color: var(--str-chat__secondary-background-color);
+  --str-chat__thread-header-border-block-start: none;
+  --str-chat__thread-header-border-block-end: none;
+  --str-chat__thread-header-border-inline-start: none;
+  --str-chat__thread-header-border-inline-end: none;
+  --str-chat__thread-header-box-shadow: none;
+  --str-chat__thread-header-info-color: var(--str-chat__text-low-emphasis-color);
+}
+
+.str-chat__thread-container {
+  @include utils.component-layer-overrides('thread');
+
+  .str-chat__thread-header {
+    @include utils.component-layer-overrides('thread-header');
+
+    .str-chat__thread-header-name {
+      font-size: 1rem;
+      line-height: 1.25rem;
+      font-weight: 500;
+    }
+
+    .str-chat__thread-header-channel-name {
+      font-size: 0.875rem;
+      line-height: 1rem;
+      color: var(--str-chat__thread-header-info-color);
+      font-weight: 400;
+    }
+
+    .str-chat__close-thread-button {
+      background-color: transparent;
+      border: none;
+
+      svg path {
+        fill: var(--str-chat__thread-color);
+      }
+    }
+  }
+}

--- a/src-v2/styles/_utils.scss
+++ b/src-v2/styles/_utils.scss
@@ -30,3 +30,117 @@
     color: var(--str-chat__#{$component-name}-disabled-color);
   }
 }
+
+@mixin circle-fab-overrides($component-name) {
+  svg path {
+    fill: var(--str-chat__#{$component-name}-color);
+  }
+
+  &:active {
+    background-color: var(--str-chat__#{$component-name}-pressed-background-color);
+  }
+}
+
+@mixin header-layout {
+  // & selector is required for the postcss-logical plugin to properly transform the logical properties
+  /* stylelint-disable-next-line scss/selector-no-redundant-nesting-selector */
+  & {
+    display: flex;
+    padding: var(--str-chat__spacing-2);
+    column-gap: var(--str-chat__spacing-4);
+    align-items: center;
+  }
+}
+
+@mixin header-text-layout {
+  // & selector is required for the postcss-logical plugin to properly transform the logical properties
+  /* stylelint-disable-next-line scss/selector-no-redundant-nesting-selector */
+  & {
+    display: flex;
+    flex-direction: column;
+    overflow-x: hidden; // for ellipsis text
+    width: 100%;
+    row-gap: var(--str-chat__spacing-1_5);
+  }
+}
+
+@mixin empty-layout {
+  // & selector is required for the postcss-logical plugin to properly transform the logical properties
+  /* stylelint-disable-next-line scss/selector-no-redundant-nesting-selector */
+  & {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: var(--str-chat__spacing-4);
+
+    svg {
+      width: calc(var(--str-chat__spacing-px) * 136);
+      height: calc(var(--str-chat__spacing-px) * 136);
+    }
+  }
+}
+
+@mixin empty-theme($component-name) {
+  // & selector is required for the postcss-logical plugin to properly transform the logical properties
+  /* stylelint-disable-next-line scss/selector-no-redundant-nesting-selector */
+  & {
+    font-size: 1.5rem;
+    line-height: 1.5rem;
+    text-align: center;
+
+    svg path {
+      fill: var(--str-chat__#{$component-name}-empty-indicator-color);
+    }
+  }
+}
+
+@mixin message-list-spacing {
+  // & selector is required for the postcss-logical plugin to properly transform the logical properties
+  /* stylelint-disable-next-line scss/selector-no-redundant-nesting-selector */
+  & {
+    padding: 0 var(--str-chat__spacing-2);
+
+    @media only screen and (min-device-width: 768px) {
+      /* stylelint-disable-next-line scss/selector-no-redundant-nesting-selector */
+      & {
+        padding: 0 var(--str-chat__spacing-10);
+      }
+    }
+  }
+}
+
+@mixin loading-item-background($component-name) {
+  // & selector is required for the postcss-logical plugin to properly transform the logical properties
+  /* stylelint-disable-next-line scss/selector-no-redundant-nesting-selector */
+  & {
+    background-image: linear-gradient(
+      -90deg,
+      var(--str-chat__#{$component-name}-loading-state-color) 0%,
+      var(--str-chat__#{$component-name}-loading-state-color) 100%
+    );
+  }
+}
+
+@mixin loading-animation {
+  animation: pulsate 1s linear 0s infinite alternate;
+
+  &:nth-of-type(2) {
+    animation: pulsate 1s linear 0.3334 infinite alternate;
+  }
+
+  &:last-of-type {
+    animation: pulsate 1s linear 0.6667s infinite alternate;
+  }
+
+  @keyframes pulsate {
+    from {
+      opacity: 0.5;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+}

--- a/src-v2/styles/common/CircleFAButton/CircleFAButton-layout.scss
+++ b/src-v2/styles/common/CircleFAButton/CircleFAButton-layout.scss
@@ -1,0 +1,14 @@
+.str-chat__circle-fab {
+  width: calc(var(--str-chat__spacing-px) * 42);
+  height: calc(var(--str-chat__spacing-px) * 42);
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .str-chat__circle-fab-icon {
+    display: inline-block;
+    height: calc(var(--str-chat__spacing-px) * 24);
+  }
+}

--- a/src-v2/styles/common/CircleFAButton/CircleFAButton-theme.scss
+++ b/src-v2/styles/common/CircleFAButton/CircleFAButton-theme.scss
@@ -1,0 +1,19 @@
+@use '../../utils';
+
+.str-chat {
+  --str-chat__circle-fab-font-family: var(--str-chat__font-family);
+  --str-chat__circle-fab-border-radius: var(--str-chat__border-radius-circle);
+  --str-chat__circle-fab-color: var(--str-chat__primary-color);
+  --str-chat__circle-fab-background-color: var(--str-chat__secondary-background-color);
+  --str-chat__circle-fab-pressed-background-color: var(--str-chat__surface-color);
+  --str-chat__circle-fab-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+  --str-chat__circle-fab-border-block-start: none;
+  --str-chat__circle-fab-border-block-end: none;
+  --str-chat__circle-fab-border-inline-start: none;
+  --str-chat__circle-fab-border-inline-end: none;
+}
+
+.str-chat__circle-fab {
+  @include utils.component-layer-overrides('circle-fab');
+  @include utils.circle-fab-overrides('circle-fab');
+}

--- a/src-v2/styles/index.layout.scss
+++ b/src-v2/styles/index.layout.scss
@@ -1,7 +1,12 @@
 @use 'theme-variables';
 @use 'common';
 
-@use 'common/CTAButton/CTAButton-layout.scss';
+@use 'common/CTAButton/CTAButton-layout';
+@use 'common/CircleFAButton/CircleFAButton-layout';
 @use 'ChannelList/ChannelList-layout';
 @use 'ChannelPreview/ChannelPreview-layout';
 @use 'Avatar/Avatar-layout';
+@use 'Channel/Channel-layout';
+@use 'MessageList/MessageList-layout';
+@use 'ChannelHeader/ChannelHeader-layout';
+@use 'Thread/Thread-layout';

--- a/src-v2/styles/index.scss
+++ b/src-v2/styles/index.scss
@@ -1,5 +1,10 @@
 @use 'index.layout.scss';
-@use 'common/CTAButton/CTAButton-theme.scss';
+@use 'common/CTAButton/CTAButton-theme';
+@use 'common/CircleFAButton/CircleFAButton-theme';
 @use 'ChannelList/ChannelList-theme';
 @use 'ChannelPreview/ChannelPreview-theme';
 @use 'Avatar/Avatar-theme';
+@use 'MessageList/MessageList-theme';
+@use 'ChannelHeader/ChannelHeader-theme';
+@use 'Thread/Thread-theme';
+@use 'Channel/Channel-theme.scss';

--- a/src/styles/MessageNotification.scss
+++ b/src/styles/MessageNotification.scss
@@ -27,6 +27,11 @@
     color: var(--primary-color);
     box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
 
+    .str-chat__jump-to-latest-icon {
+      display: inline-block;
+      height: 24px;
+    }
+
     &-unread-count {
       font-size: 10px;
       left: 50%;

--- a/src/styles/Thread.scss
+++ b/src/styles/Thread.scss
@@ -10,6 +10,13 @@
   flex-direction: column;
   padding-top: 0;
 
+  .str-chat__thread-container {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+
   &--full {
     max-width: 100%;
   }
@@ -29,10 +36,11 @@
 
     &-details {
       font-size: var(--md-font);
+      font-weight: bold;
 
-      small {
-        display: block;
+      .str-chat__thread-header-channel-name {
         font-size: var(--sm-font);
+        font-weight: normal;
       }
     }
   }
@@ -184,8 +192,17 @@
         background: var(--white);
         box-shadow: 0 2px 9px 0 var(--border), 0 1px 0 0 var(--border);
 
+        .str-chat__thread-header-details {
+          width: 100%;
+        }
+
         .str-chat__square-button {
           cursor: pointer;
+
+          svg {
+            width: 21px;
+            height: 21px;
+          }
         }
       }
 


### PR DESCRIPTION
Components in this PR:
- Channel
- Channel header
- Thread header
- Thread
- Message list
- Jump to latest message

Responsive layout implemented in sample app, guide added to the [docs](https://github.com/GetStream/stream-chat-angular/pull/294/files#diff-99a4712356eb08af71235cafa9f1fe2615b9b8a718fd18f9b9cd3483ac792780) - maybe this could be a shared guide between React and Angular, I guess only the HTML snippets are framework-specific here

| Descripition | Figma | Implementation |
|-------------|--------|----------------|
| Channel header + jump to latest message button - light | <img width="417" alt="Screenshot 2022-05-20 at 16 37 43" src="https://user-images.githubusercontent.com/6690098/169551395-91b0fb15-fcff-4aae-8da6-a17ea6bfe7e2.png"> | <img width="946" alt="Screenshot 2022-05-20 at 11 39 57" src="https://user-images.githubusercontent.com/6690098/169551452-85d3ab76-5062-4da3-9824-4ec44e1ebc38.png"> |
| Channel header + jump to latest message button - dark | <img width="418" alt="Screenshot 2022-05-20 at 16 39 24" src="https://user-images.githubusercontent.com/6690098/169551701-98a69b4f-7412-407c-8640-9363d026cd00.png">|<img width="768" alt="Screenshot 2022-05-20 at 16 29 21" src="https://user-images.githubusercontent.com/6690098/169551831-d2ca1e83-bdde-4d32-9af2-0173a7148110.png"> |
| Thread header + jump to latest message button - light | <img width="202" alt="Screenshot 2022-05-20 at 16 41 23" src="https://user-images.githubusercontent.com/6690098/169552330-bc7b25e0-f914-411d-845f-7a0594c37de5.png"> | <img width="426" alt="Screenshot 2022-05-20 at 11 40 06" src="https://user-images.githubusercontent.com/6690098/169552545-af806fcc-2d1d-4e4c-a86d-07e9bfac7048.png"> close button is on the right because theme-v1 looked really bad if close button was on the left|
| Thread header + jump to latest message button - dark | <img width="202" alt="Screenshot 2022-05-20 at 16 44 57" src="https://user-images.githubusercontent.com/6690098/169553211-c017793c-e015-4ccf-90ee-b3cc432e10f8.png"> |<img width="347" alt="Screenshot 2022-05-20 at 16 29 26" src="https://user-images.githubusercontent.com/6690098/169553075-c1517081-cdf4-4865-8a53-cc8c70c9168f.png"> |
| Loading state - light | <img width="633" alt="Screenshot 2022-05-20 at 16 46 10" src="https://user-images.githubusercontent.com/6690098/169553453-dabc5057-52ea-4cc0-9b7b-b8eb873f280a.png"> | <img width="945" alt="Screenshot 2022-05-20 at 16 15 14" src="https://user-images.githubusercontent.com/6690098/169553506-d54fbb2c-4a08-403b-903d-4690ce751994.png"> |
| Loading state - dark | <img width="633" alt="Screenshot 2022-05-20 at 16 47 15" src="https://user-images.githubusercontent.com/6690098/169553677-d2be6776-798e-4cda-bf71-8861d0478fe1.png"> | <img width="1171" alt="Screenshot 2022-05-20 at 16 26 49" src="https://user-images.githubusercontent.com/6690098/169553706-71850416-4721-4b96-8cda-f3ce44d8aebe.png"> |
No channel selected - light | <img width="483" alt="Screenshot 2022-05-20 at 16 49 57" src="https://user-images.githubusercontent.com/6690098/169554189-90162e7c-99c9-47c3-99a9-848f6fde51f7.png"> | <img width="1033" alt="Screenshot 2022-05-20 at 16 19 15" src="https://user-images.githubusercontent.com/6690098/169554241-6f38003b-ce52-4523-b00a-2ac51dcba921.png"> |
No channel selected - dark | <img width="473" alt="Screenshot 2022-05-20 at 16 50 41" src="https://user-images.githubusercontent.com/6690098/169554330-08b171d6-069e-4c3c-a170-da619c97b602.png"> | <img width="1039" alt="Screenshot 2022-05-20 at 16 19 49" src="https://user-images.githubusercontent.com/6690098/169554373-7c64e266-e4ae-4a3e-9842-1d04d1e70682.png">


Changes in theme-v1: thread header

<img width="519" alt="Screenshot 2022-05-20 at 11 41 24" src="https://user-images.githubusercontent.com/6690098/169554487-60582757-c96d-4987-bc73-36fe676f28af.png">



closes #91 