### PR TITLE
fix: remove 100% width on threads message inner component

### DIFF
--- a/src/styles/Thread.scss
+++ b/src/styles/Thread.scss
@@ -61,7 +61,6 @@
     .str-chat__message:first-of-type .str-chat__message-inner {
       margin-left: unset;
       margin-right: unset;
-      width: 100%;
     }
 
     .str-chat__message-attachment.str-chat__message-attachment {


### PR DESCRIPTION
### 🎯 Goal

Messages which content does not take the whole width should have the message options icons visible on hover without overflowing the parent message list container. This is a regression bug fix for https://github.com/GetStream/stream-chat-css/commit/d8d17300bfa50e399afb7c591808b6d11b795f9f

This fix does not solve the problem of message options overflow when the message content takes the whole width of the thread container.


### 🎨 UI Changes

Fixes:
![image](https://user-images.githubusercontent.com/32706194/172361731-b0298ad8-c0f2-488f-b595-3fad617bace7.png)

Does not fix:
![image](https://user-images.githubusercontent.com/32706194/172362087-bcf8675c-f9d3-4663-8dcc-057368495a0f.png)


