### PR TITLE
feat: make loading indicator container float above the MessageList

### DIFF
--- a/src/styles/MessageList.scss
+++ b/src/styles/MessageList.scss
@@ -3,15 +3,30 @@
   overflow-y: auto;
 }
 
+// conditionally showing the loading indicator displaces items when prepending.
+// a simple workaround is to make the loading indicator an overlay.
+%loading-indicator-container {
+  display: flex;
+  padding-top: var(--xs-p);
+  justify-content: center;
+  width: 100%;
+  position: absolute;
+}
+
 .str-chat-angular__message-list-host {
   @extend %scrollable;
 }
 
 .str-chat__list {
   @extend %scrollable;
+  position: relative;
   flex: 1;
   -webkit-overflow-scrolling: touch; /* enable smooth scrolling on ios */
   padding: 0;
+
+  &__loading {
+    @extend %loading-indicator-container;
+  }
 
   .str-chat__reverse-infinite-scroll {
     padding-top: 72px;
@@ -177,14 +192,8 @@
   width: 100%;
   height: 100%;
 
-  // conditionally showing the header displaces items when prepending.
-  // a simple workaround is to make the loading indicator an overlay.
   &__loading {
-    display: flex;
-    padding-top: var(--xs-p);
-    justify-content: center;
-    width: 100%;
-    position: absolute;
+    @extend %loading-indicator-container;
   }
 
   p {


### PR DESCRIPTION
### 🎯 Goal

By giving the loading indicator's container absolute positioning, it can be removed from the flow of the messages in the `MessageList`. It also gets rid of the jumping while scrolling up and loading new messages, because now the `MessageList` height will not change until new messages are loaded.