### PR TITLE
fix: Long quoted message in message input

### DIFF
--- a/src/v2/styles/Message/Message-layout.scss
+++ b/src/v2/styles/Message/Message-layout.scss
@@ -237,5 +237,23 @@
   .str-chat__quoted-message-bubble {
     flex-direction: column;
     align-items: stretch;
+    row-gap: var(--str-chat__spacing-1);
+  }
+}
+
+.str-chat__message-input {
+  .str-chat__quoted-message-bubble {
+    max-height: calc(var(--str-chat__spacing-px) * 200);
+
+    .str-chat__quoted-message-text {
+      max-height: 100%;
+      min-height: 0;
+
+      p {
+        max-height: 100%;
+        overflow-y: auto;
+        overflow-x: hidden;
+      }
+    }
   }
 }


### PR DESCRIPTION
### 🎯 Goal

_Describe why we are making this change_

### 🛠 Implementation details

_Provide a description of the implementation_

### 🎨 UI Changes

Before

<img width="371" alt="Screenshot 2022-06-17 at 15 09 57" src="https://user-images.githubusercontent.com/6690098/174305592-63ed4386-5ef9-4cca-b8f0-6a32b3c223fc.png">

After

<img width="374" alt="Screenshot 2022-06-17 at 15 10 14" src="https://user-images.githubusercontent.com/6690098/174305610-75250abf-dd8f-4073-89ca-493007dafb34.png">

