### PR TITLE
fix: Context menu and tooltip position in Angular (theme-v1 and v2)

### DIFF
--- a/src/v1/MessageActions.scss
+++ b/src/v1/MessageActions.scss
@@ -9,6 +9,12 @@
   background-image: linear-gradient(-180deg, var(--bg-gradient-start), var(--bg-gradient-end));
   box-shadow: 0 0 2px 0 var(--border), 0 1px 0 0 var(--border), 0 1px 8px 0 var(--border);
   z-index: 999;
+
+  &.str-chat__message-actions-box-angular {
+    position: initial;
+    margin: 8px;
+    border-radius: var(--border-radius);
+  }
 }
 
 .str-chat__message-actions-box--open {
@@ -108,5 +114,20 @@
   button {
     display: flex;
     align-items: center;
+  }
+}
+
+.str-chat__message-edit-in-progress {
+  .ngxp__container {
+    transform: initial !important;
+    will-change: initial !important;
+  }
+}
+
+.str-chat__message-edit-in-progress {
+  .ngxp__container {
+    transform: initial !important;
+    will-change: initial !important;
+    z-index: 2;
   }
 }

--- a/src/v1/Tooltip.scss
+++ b/src/v1/Tooltip.scss
@@ -1,7 +1,4 @@
 .str-chat__tooltip {
-  position: absolute;
-  right: 0;
-  bottom: calc(100% + 10px);
   display: flex;
   background: var(--black);
   border-radius: var(--border-radius-sm);
@@ -24,6 +21,12 @@
     color: var(--primary-color);
     text-decoration: none;
   }
+}
+
+.str-chat__tooltip:not(.str-chat__tooltip-angular) {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 10px);
 
   &::after {
     content: '';

--- a/src/v1/_base.scss
+++ b/src/v1/_base.scss
@@ -7,6 +7,19 @@
     box-sizing: inherit;
     font-family: var(--second-font);
   }
+
+  // Overriding styles of ngx-popperjs
+  .ngxp__container {
+    z-index: 1;
+    margin: 0 !important;
+    padding: 0 !important;
+    box-shadow: none !important;
+    border: none !important;
+
+    .ngxp__arrow {
+      display: none !important;
+    }
+  }
 }
 
 .clearfix {

--- a/src/v2/styles/MessageActionsBox/MessageActionsBox-layout.scss
+++ b/src/v2/styles/MessageActionsBox/MessageActionsBox-layout.scss
@@ -1,22 +1,5 @@
 .str-chat__message-actions-box {
-  display: none;
-  position: absolute;
   overflow: hidden; // Avoids message action box item background overflow in hovered state
-  z-index: 1;
-
-  &.str-chat__message-actions-box--open {
-    display: block;
-  }
-
-  &.str-chat__message-actions-box--mine {
-    inset-block-end: 100%;
-    inset-inline-start: 100%;
-  }
-
-  &:not(.str-chat__message-actions-box--mine) {
-    inset-block-end: 100%;
-    inset-inline-end: 100%;
-  }
 
   .str-chat__message-actions-list {
     list-style: none;
@@ -32,5 +15,32 @@
       width: 100%;
       text-align: start;
     }
+  }
+}
+
+.str-chat__message-actions-box:not(.str-chat__message-actions-box-angular) {
+  display: none;
+  position: absolute;
+  z-index: 1;
+
+  &.str-chat__message-actions-box--open {
+    display: block;
+  }
+
+  &.str-chat__message-actions-box--mine {
+    inset-block-end: 100%;
+    inset-inline-start: 100%;
+  }
+
+  &:not(.str-chat__message-actions-box--mine) {
+    inset-block-end: 100%;
+    inset-inline-end: 100%;
+  }
+}
+
+.str-chat__message-edit-in-progress {
+  .ngxp__container {
+    transform: initial !important;
+    will-change: initial !important;
   }
 }

--- a/src/v2/styles/Tooltip/Tooltip-layout.scss
+++ b/src/v2/styles/Tooltip/Tooltip-layout.scss
@@ -1,15 +1,18 @@
 @use '../utils';
 
 .str-chat__tooltip {
-  $size: 10px;
-
-  position: absolute;
-  bottom: calc(100% + calc(#{$size} / 2));
   display: flex;
   padding: var(--str-chat__spacing-2);
+}
+
+.str-chat__tooltip:not(.str-chat__tooltip-angular) {
+  $size: 10px;
+
   min-width: calc(var(--str-chat__spacing-px) * 100px);
   max-width: calc(var(--str-chat__spacing-px) * 150px);
   word-break: break-all;
+  position: absolute;
+  bottom: calc(100% + calc(#{$size} / 2));
 
   &::after {
     content: '';

--- a/src/v2/styles/_base.scss
+++ b/src/v2/styles/_base.scss
@@ -4,6 +4,19 @@
   * {
     box-sizing: border-box;
   }
+
+  // Overriding styles of ngx-popperjs
+  .ngxp__container {
+    z-index: 1;
+    margin: 0 !important;
+    padding: 0 !important;
+    box-shadow: none !important;
+    border: none !important;
+
+    .ngxp__arrow {
+      display: none !important;
+    }
+  }
 }
 
 // Fixes icon sizing problem in Angular SDK


### PR DESCRIPTION
### 🎯 Goal

Message actions context menu and tooltip components had a static position, which meant that they could easily overflow and not be properly visible. This is now fixed in Angular (both for theme-v1 and v2) this PR contains
- Rules for the dynamic positioning
- Turns off the static positioning in Angular

Angular changes: https://github.com/GetStream/stream-chat-angular/pull/317

React is not affected by this PR.

### 🛠 Implementation details

_Provide a description of the implementation_

### 🎨 UI Changes

_Add relevant screenshots_
