### PR TITLE
fix: Consolidate React and Angular notification styles

### DIFF
--- a/src/v2/styles/Notification/MessageNotification-layout.scss
+++ b/src/v2/styles/Notification/MessageNotification-layout.scss
@@ -1,11 +1,3 @@
-.str-chat__list-notifications {
-  padding: 0 var(--str-chat__spacing-10);
-  display: flex;
-  position: relative;
-  flex-direction: column;
-  justify-content: center;
-}
-
 .str-chat__message-notification {
   display: block;
   position: absolute;
@@ -13,4 +5,8 @@
   padding: var(--str-chat__spacing-1) var(--str-chat__spacing-2);
   bottom: calc(var(--str-chat__spacing-px) * 10);
   z-index: 101;
+}
+
+.str-chat__list-notifications {
+  position: relative;
 }

--- a/src/v2/styles/Notification/MessageNotification-theme.scss
+++ b/src/v2/styles/Notification/MessageNotification-theme.scss
@@ -17,18 +17,3 @@
   font-size: 0.75rem;
   cursor: pointer;
 }
-
-.messaging.str-chat {
-  .str-chat__list-notifications {
-    background: var(--str-chat__on-primary-color);
-  }
-  @media screen and (max-width: 960px) {
-    .str-chat__list-notifications {
-      padding: 0 var(--str-chat__spacing-2);
-    }
-  }
-
-  &.dark .str-chat__list-notifications {
-    background: var(--str-chat__on-primary-color);
-  }
-}

--- a/src/v2/styles/index.layout.scss
+++ b/src/v2/styles/index.layout.scss
@@ -19,10 +19,10 @@
 @use 'MessageInput/MessageInput-layout';
 @use 'MessageList/MessageList-layout';
 @use 'MessageList/VirtualMessageList-layout';
-@use 'MessageNotifications/MessageNotifications-layout';
 @use 'MessageReactions/MessageReactions-layout';
 @use 'MessageReactions/MessageReactionsSelector-layout';
 @use 'Modal/Modal-layout';
+@use 'Notification/MessageNotification-layout';
 @use 'Notification/NotificationList-layout';
 @use 'Notification/Notification-layout';
 @use 'Thread/Thread-layout';

--- a/src/v2/styles/index.scss
+++ b/src/v2/styles/index.scss
@@ -16,10 +16,10 @@
 @use 'MessageInput/MessageInput-theme';
 @use 'MessageList/MessageList-theme';
 @use 'MessageList/VirtualMessageList-theme';
-@use 'MessageNotifications/MessageNotifications-theme.scss';
 @use 'MessageReactions/MessageReactions-theme';
 @use 'MessageReactions/MessageReactionsSelector-theme';
 @use 'Modal/Modal-theme';
+@use 'Notification/MessageNotification-theme';
 @use 'Notification/NotificationList-theme';
 @use 'Notification/Notification-theme';
 @use 'Thread/Thread-theme';


### PR DESCRIPTION
### 🎯 Goal

Angular and React have different notification handling. This PR consolidates the styles of the Angular notifications and the React "New messages" notificaion.

### 🛠 Implementation details

- The `MessageNotification` component had a few CSS rules that targeted the `str-chat__list-notifications` -> removed the ones that shouldn't be inside the `MessageNotification`
- Moved all notification CSS code inside the `Notification` folder

### 🎨 UI Changes

_Add relevant screenshots_
