### PR TITLE
fix: Docusuarus CI error

### DIFF
--- a/docs/theming/SDKSpecific.jsx
+++ b/docs/theming/SDKSpecific.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 
 const SDKSpecific = ({ children, name = 'angular' }) => (
-  <>{window.location.pathname.includes(`/sdk/${name}`) ? children : null}</>
+  <BrowserOnly>
+    {window.location.pathname.includes(`/sdk/${name}`) ? children : null}
+  </BrowserOnly>
 );
 
 export default SDKSpecific;


### PR DESCRIPTION
### 🎯 Goal

I didin't have this problem when locally running the docs, but in CI I got this error:

```
Error:  Docusaurus Node/SSR could not render static page with path /angular/theming/themingv2/ because of following error:
ReferenceError: window is not defined
    at SDKSpecific (main:21[69](https://github.com/GetStream/stream-chat-angular/runs/7278758300?check_suite_focus=true#step:14:71)6:101)
    at d (main:63582:498)
    at bb (main:63585:16)
    at a.b.render (main:63591:43)
    at a.b.read (main:63590:83)
    at Object.exports.renderToString (main:63601:138)
    at doRender (main:14408:356)
    at async serverEntry_render (main:14404:284)
[INFO] It looks like you are using code that should run on the client-side only.
To get around it, try using `<BrowserOnly>` (https://docusaurus.io/docs/docusaurus-core/#browseronly) or `ExecutionEnvironment`
```

### 🛠 Implementation details

Followed https://docusaurus.io/docs/docusaurus-core/#browseronly to fix the error

### 🎨 UI Changes

_Add relevant screenshots_
