### PR TITLE
fix: enable margin between own image message and following text message

### DIFF
--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -440,7 +440,7 @@
 
   /* me */
   &--me {
-    display: flex;
+    display: inline-flex;
     margin: var(--xxs-m) 0;
     justify-content: flex-end;
 


### PR DESCRIPTION
### 🎯 Goal

Margins between own image message and text message were collapsed. This was due to use of `display: flex` on `.str-chat__message-simple--me` container. This was not happening between the image and text message of other channel members.

### 🎨 UI Changes

Before:
![image](https://user-images.githubusercontent.com/32706194/179232899-f159bcae-c8a8-46d9-9c29-de271b2f3dbb.png)

After:
![image](https://user-images.githubusercontent.com/32706194/179232972-e9170929-6aef-43a1-b46c-62b20175d0fc.png)

