### PR TITLE
v2.10.1

### DIFF
--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -440,7 +440,7 @@
 
   /* me */
   &--me {
-    display: flex;
+    display: inline-flex;
     margin: var(--xxs-m) 0;
     justify-content: flex-end;
 


### PR DESCRIPTION
fix: enable margin between image message and following text message (https://github.com/GetStream/stream-chat-css/pull/152)
