### PR TITLE
fix: Emoji display in Angular

### DIFF
--- a/src/v2/styles/MessageReactions/MessageReactions-layout.scss
+++ b/src/v2/styles/MessageReactions/MessageReactions-layout.scss
@@ -26,7 +26,7 @@
 
       .str-chat__message-reaction-emoji {
         height: calc(var(--str-chat__spacing-px) * 13);
-        display: flex; // Overriding emoji-mart styles
+        display: flex !important; // Overriding emoji-mart styles
         align-items: center;
         justify-content: center;
       }

--- a/src/v2/styles/MessageReactions/MessageReactionsSelector-layout.scss
+++ b/src/v2/styles/MessageReactions/MessageReactionsSelector-layout.scss
@@ -22,7 +22,7 @@
 
       .str-chat__message-reaction-emoji {
         height: calc(var(--str-chat__spacing-px) * 20);
-        display: flex; // Overriding emoji-mart styles
+        display: flex !important; // Overriding emoji-mart styles
         align-items: center;
         justify-content: center;
       }


### PR DESCRIPTION
### 🎯 Goal

This took me quite some time to figure out, but this should only be present in Angular SDK, but the `~@ctrl/ngx-emoji-mart/picker` stylesheets (imported by Angular SDK when the emoji selector button is added) conflict with styling in the message reactions.

### 🛠 Implementation details

### 🎨 UI Changes

_Add relevant screenshots_
