### PR TITLE
Font theming variables

### DIFF
--- a/scripts/output.ts
+++ b/scripts/output.ts
@@ -20,7 +20,7 @@ export const getThemeVariablesOutput = (data: Map<string, VariableInfo>) => {
   
   const groups = [
     {name: 'Colors', regexp: /color/, columns: [nameColumn, valueColumn, valueDarkColumn, descriptionColumn, usedInColumn]},
-    {name: 'Fonts', regexp: /__font-family/, columns: [nameColumn, valueColumn, descriptionColumn, usedInColumn]},
+    {name: 'Fonts', regexp: /(__font|-text)/, columns: [nameColumn, valueColumn, descriptionColumn, usedInColumn]},
     {name: 'Spacing', regexp: /spacing/, columns: [nameColumn, valueColumn, descriptionColumn]},
     {name: 'Radius', regexp: /__border-radius/, columns: [nameColumn, valueColumn, descriptionColumn, usedInColumn]},
     {name: 'Others', regexp: /.*/, columns: [nameColumn, valueColumn, descriptionColumn]}

--- a/scripts/parser.ts
+++ b/scripts/parser.ts
@@ -71,20 +71,20 @@ export const extractVariables = (fromGlob: string, dependencies?: Map<string, Va
               seenVariable.value = currentVariable.value;
             }
           }
+        }
 
-          if (dependencies) {
-            const value = currentVariable.value;
-            // matches against multiple var() invocations in the same rule
-            // e.g.: padding: var(--xs-p) var(--xl-p);
-            const matches = value.match(/var\(([\w\s,-]+)\)/g);
-            if (matches) {
-              matches.forEach((match) => {
-                // capture the variable name, e.g.: "var(--xl-p)" -> "--xl-p"
-                const [, variable] = match.match(/var\(([\w\s-]+)\)/)!;
-                const dependantVariable = dependencies.get(variable.trim());
-                dependantVariable?.referencedIn.add(componentName);
-              });
-            }
+        if (dependencies) {
+          const value = node.text;
+          // matches against multiple var() invocations in the same rule
+          // e.g.: padding: var(--xs-p) var(--xl-p);
+          const matches = value.match(/var\(([\w\s,-]+)\)/g);
+          if (matches) {
+            matches.forEach((match) => {
+              // capture the variable name, e.g.: "var(--xl-p)" -> "--xl-p"
+              const [, variable] = match.match(/var\(([\w\s-]+)\)/)!;
+              const dependantVariable = dependencies.get(variable.trim());
+              dependantVariable?.referencedIn.add(componentName);
+            });
           }
         }
       });

--- a/src/v2/styles/AttachmentList/AttachmentList-theme.scss
+++ b/src/v2/styles/AttachmentList/AttachmentList-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__attachment-list-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__attachment-list-border-radius: 0;
 
@@ -27,9 +24,6 @@
 
   /* Box shadow applied to the component */
   --str-chat__attachment-list-box-shadow: none;
-
-  /* The font used in image attachments */
-  --str-chat__image-attachment-font-family: var(--str-chat__font-family);
 
   /* The border radius used for the borders of image attachments */
   --str-chat__image-attachment-border-radius: calc(
@@ -56,9 +50,6 @@
 
   /* Box shadow applied to image gallery attachments */
   --str-chat__image-attachment-box-shadow: none;
-
-  /* The font used in image gallery attachments */
-  --str-chat__image-gallery-attachment-font-family: var(--str-chat__font-family);
 
   /* The border radius used for the borders of image gallery attachments */
   --str-chat__image-gallery-attachment-border-radius: calc(
@@ -94,9 +85,6 @@
     --str-chat__secondary-overlay-text-color
   );
 
-  /* The font used in card attachments */
-  --str-chat__card-attachment-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of card attachments */
   --str-chat__card-attachment-border-radius: 0;
 
@@ -123,9 +111,6 @@
 
   /* Box shadow applied to card attachments */
   --str-chat__card-attachment-box-shadow: none;
-
-  /* The font used in file attachments */
-  --str-chat__file-attachment-font-family: var(--str-chat__font-family);
 
   /* The border radius used for the borders of file attachments */
   --str-chat__file-attachment-border-radius: calc(
@@ -156,11 +141,10 @@
   /* Box shadow applied to file attachments */
   --str-chat__file-attachment-box-shadow: none;
 
-  /* The font used in audio widget */
-  --str-chat__audio-attachment-widget-font-family: var(--str-chat__font-family);
-
   /* Border radius applied audio widget */
-  --str-chat__audio-attachment-widget-border-radius: calc(var(--str-chat__message-bubble-border-radius) - var(--str-chat__attachment-margin));
+  --str-chat__audio-attachment-widget-border-radius: calc(
+    var(--str-chat__message-bubble-border-radius) - var(--str-chat__attachment-margin)
+  );
 
   /* Text color used in audio widget */
   --str-chat__audio-attachment-widget-color: var(--str-chat__text-color);
@@ -193,10 +177,14 @@
   --str-chat__audio-attachment-controls-button-color: var(--str-chat__text-color);
 
   /* Background color applied to audio widget's play / pause button */
-  --str-chat__audio-attachment-controls-button-background-color: var(--str-chat__secondary-background-color);
+  --str-chat__audio-attachment-controls-button-background-color: var(
+    --str-chat__secondary-background-color
+  );
 
   /* Background color applied to audio widget's play / pause button when in pressed (active) state */
-  --str-chat__audio-attachment-controls-button-pressed-background-color: var(--str-chat__surface-color);
+  --str-chat__audio-attachment-controls-button-pressed-background-color: var(
+    --str-chat__surface-color
+  );
 
   /* Top border of audio widget's play / pause button */
   --str-chat__audio-attachment-controls-button-border-block-start: none;
@@ -212,9 +200,6 @@
 
   /* Box shadow applied to audio widget's play / pause button */
   --str-chat__audio-attachment-controls-button-box-shadow: var(--str-chat__circle-fab-box-shadow);
-
-  /* The font used in attachment actions */
-  --str-chat__attachment-actions-font-family: var(--str-chat__font-family);
 
   /* The border radius used for attachment actions */
   --str-chat__attachment-actions-border-radius: 0;
@@ -239,9 +224,6 @@
 
   /* Box shadow applied to attachment actions */
   --str-chat__attachment-actions-box-shadow: none;
-
-  /* The font used in an attachment action */
-  --str-chat__attachment-action-font-family: var(--str-chat__font-family);
 
   /* The border radius used for an attachment action */
   --str-chat__attachment-action-border-radius: 0;
@@ -300,8 +282,7 @@
       color: var(--str-chat__image-gallery-attachment-overlay-text-color);
       display: flex;
       border: none;
-      font-size: 1.8rem;
-      line-height: 1.8rem;
+      font: var(--str-chat__headline2-text);
 
       &::after {
         background-color: var(--str-chat__image-gallery-attachment-overlay);
@@ -317,15 +298,12 @@
   .str-chat__message-attachment-audio-widget {
     .str-chat__message-attachment-file--item-name,
     .str-chat__message-attachment-audio-widget--title {
-      font-size: 1rem;
-      line-height: 1.25rem;
-      font-weight: 500;
+      font: var(--str-chat__subtitle-medium-text);
     }
 
     .str-chat__message-attachment-file--item-size {
       color: var(--str-chat__file-attachment-secondary-color);
-      font-size: 0.875rem;
-      line-height: 1rem;
+      font: var(--str-chat__body-text);
     }
 
     .str-chat__message-attachment-download-icon {
@@ -354,15 +332,14 @@
 
   .str-chat__message-attachment--card {
     @include utils.component-layer-overrides('card-attachment');
-    font-size: 0.875rem;
-    line-height: 1rem;
+    font: var(--str-chat__body-text);
 
     .str-chat__message-attachment-card--source-link {
-      font-weight: 500;
+      font: var(--str-chat__body-medium-text);
     }
 
     .str-chat__message-attachment-card--title {
-      font-weight: 500;
+      font: var(--str-chat__body-medium-text);
     }
   }
 
@@ -384,9 +361,7 @@
 
       .str-chat__message-attachment-audio-widget--title {
         color: var(--str-chat__text-color);
-        font-weight: 500;
-        font-size: 14px;
-        line-height: 16px;
+        font: var(--str-chat__body-medium-text);
       }
     }
   }
@@ -396,9 +371,7 @@
 
     .str-chat__message-attachment-actions-button {
       @include utils.component-layer-overrides('attachment-action');
-      font-weight: 500;
-      font-size: 1rem;
-      line-height: 1.25rem;
+      font: var(--str-chat__subtitle-medium-text);
       border-collapse: collapse;
 
       &:active {

--- a/src/v2/styles/AttachmentPreviewList/AttachmentPreviewList-theme.scss
+++ b/src/v2/styles/AttachmentPreviewList/AttachmentPreviewList-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__attachment-preview-list-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__attachment-preview-list-border-radius: var(--str-chat__border-radius-sm);
 
@@ -43,9 +40,6 @@
   /* Overlay color applied to attachment previews during upload and if an error occured during upload */
   --str-chat__attachment-preview-overlay-color: var(--str-chat__overlay-color);
 
-  /* The font used in the image preview */
-  --str-chat__attachment-preview-image-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the image preview */
   --str-chat__attachment-preview-image-border-radius: var(--str-chat__border-radius-sm);
 
@@ -69,9 +63,6 @@
 
   /* Box shadow applied to the image preview */
   --str-chat__attachment-preview-image-box-shadow: none;
-
-  /* The font used in the file preview */
-  --str-chat__attachment-preview-file-font-family: var(--str-chat__font-family);
 
   /* The border radius used for the borders of the file preview */
   --str-chat__attachment-preview-file-border-radius: var(--str-chat__border-radius-md);
@@ -120,9 +111,7 @@
     @include utils.component-layer-overrides('attachment-preview-file');
 
     .str-chat__attachment-preview-file-name {
-      font-size: 1rem;
-      line-height: 1.25rem;
-      font-weight: 500;
+      font: var(--str-chat__subtitle-medium-text);
     }
 
     .str-chat__attachment-preview-file-download {

--- a/src/v2/styles/Autocomplete/Autocomplete-theme.scss
+++ b/src/v2/styles/Autocomplete/Autocomplete-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__autocomplete-menu-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__autocomplete-menu-border-radius: var(--str-chat__border-radius-xs);
 
@@ -31,40 +28,34 @@
   /* The background color of a selected autocomplete item */
   --str-chat__autocomplete-active-background-color: var(--str-chat__surface-color);
 
-  /* The font used in the component (ReactSDK) */
-  --str-chat__suggestion-list-container-font-family: var(--str-chat__font-family);
- 
   /* The border radius used for the borders of the component (ReactSDK) */
   --str-chat__suggestion-list-container-border-radius: var(--str-chat__border-radius-xs);
- 
+
   /* The text/icon color of the component (ReactSDK) */
   --str-chat__suggestion-list-container-color: var(--str-chat__text-color);
- 
+
   /* The background color of the component (ReactSDK) */
   --str-chat__suggestion-list-container-background-color: var(
     --str-chat__secondary-background-color
   );
- 
+
   /* Top border of the component (ReactSDK) */
   --str-chat__suggestion-list-container-border-block-start: none;
- 
+
   /* Bottom border of the component (ReactSDK) */
   --str-chat__suggestion-list-container-border-block-end: none;
- 
+
   /* Left (right in RTL layout) border of the component (ReactSDK) */
   --str-chat__suggestion-list-container-border-inline-start: none;
- 
+
   /* Right (left in RTL layout) border of the component (ReactSDK) */
   --str-chat__suggestion-list-container-border-inline-end: none;
-  
+
   /* Box shadow applied to the component (ReactSDK) */
   --str-chat__suggestion-list-container-box-shadow: 0 0 8px rgba(0, 0, 0, 0.15);
 
   /* The background color of a selected autocomplete item (ReactSDK) */
   --str-chat__suggestion-list-item--selected-background-color: var(--str-chat__surface-color);
-
-  /* The font used in the slash command item in the autocomplete list */
-  --str-chat__slash-command-font-family: var(--str-chat__font-family);
 
   /* The border radius used for the borders of the slash command item in the autocomplete list */
   --str-chat__slash-command-border-radius: 0;
@@ -92,9 +83,6 @@
 
   /* Text color of the arguments of a slash command item in the autocomplete list */
   --str-chat__slash-command-args-color: var(--str-chat__text-low-emphasis-color);
-
-  /* The font used in the user mention item in the autocomplete list */
-  --str-chat__mention-list-user-item-font-family: var(--str-chat__font-family);
 
   /* The border radius used for the borders of the user mention item in the autocomplete list */
   --str-chat__mention-list-user-item-border-radius: 0;
@@ -145,14 +133,12 @@
   .str-chat__slash-command-header {
     .str-chat__slash-command-name {
       text-transform: capitalize;
-      font-size: 1.25rem;
-      line-height: 1.5rem;
+      font: var(--str-chat__subtitle2-text);
     }
 
     .str-chat__slash-command-args {
       color: var(--str-chat__slash-command-args-color);
-      font-size: 1rem;
-      line-height: 1.25rem;
+      font: var(--str-chat__subtitle-text);
     }
   }
 }
@@ -161,13 +147,11 @@
   @include utils.component-layer-overrides('mention-list-user-item');
 
   .str-chat__user-item--name {
-    font-size: 1rem;
-    line-height: 1.25rem;
+    font: var(--str-chat__subtitle-text);
   }
 
   .str-chat__user-item-at {
-    font-size: 1.25rem;
-    line-height: 1.25rem;
+    font: var(--str-chat__subtitle2-text);
     color: var(--str-chat__mention-list-user-item-at-sign-color);
   }
 }

--- a/src/v2/styles/Avatar/Avatar-theme.scss
+++ b/src/v2/styles/Avatar/Avatar-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__avatar-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__avatar-border-radius: var(--str-chat__border-radius-circle);
 

--- a/src/v2/styles/Channel/Channel-theme.scss
+++ b/src/v2/styles/Channel/Channel-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__channel-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__channel-border-radius: 0;
 

--- a/src/v2/styles/ChannelHeader/ChannelHeader-theme.scss
+++ b/src/v2/styles/ChannelHeader/ChannelHeader-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__channel-header-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__channel-header-border-radius: 0;
 
@@ -36,15 +33,11 @@
   @include utils.component-layer-overrides('channel-header');
 
   .str-chat__channel-header-title {
-    font-size: 1rem;
-    line-height: 1.25rem;
-    font-weight: 500;
+    font: var(--str-chat__subtitle-medium-text);
   }
 
   .str-chat__channel-header-info {
-    font-size: 0.875rem;
-    line-height: 1rem;
+    font: var(--str-chat__body-text);
     color: var(--str-chat__channel-header-info-color);
-    font-weight: 400;
   }
 }

--- a/src/v2/styles/ChannelList/ChannelList-theme.scss
+++ b/src/v2/styles/ChannelList/ChannelList-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__channel-list-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__channel-list-border-radius: 0;
 
@@ -27,9 +24,6 @@
 
   /* Right (left in RTL layout) border of the component */
   --str-chat__channel-list-border-inline-end: 1px solid var(--str-chat__surface-color);
-
-  /* The font used for the load more button */
-  --str-chat__channel-list-load-more-font-family: var(--str-chat__cta-button-font-family);
 
   /* The border radius used for the borders of the load more button */
   --str-chat__channel-list-load-more-border-radius: var(--str-chat__cta-button-border-radius);

--- a/src/v2/styles/ChannelPreview/ChannelPreview-layout.scss
+++ b/src/v2/styles/ChannelPreview/ChannelPreview-layout.scss
@@ -37,16 +37,12 @@
       display: flex;
       column-gap: var(--str-chat__spacing-1);
       align-items: center;
-      height: var(
-        --channel-name-height,
-        1rem
-      ); // Ensure that unread badge won't push container height causing an unwanted layout shift
 
       .str-chat__channel-preview-unread-badge {
         height: 100%;
         display: flex;
         align-items: center;
-        padding: var(--str-chat__spacing-2);
+        padding: 0 var(--str-chat__spacing-2);
       }
 
       .str-chat__channel-preview-messenger--name {

--- a/src/v2/styles/ChannelPreview/ChannelPreview-theme.scss
+++ b/src/v2/styles/ChannelPreview/ChannelPreview-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__channel-preview-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__channel-preview-border-radius: 0;
 
@@ -62,7 +59,6 @@
 }
 
 .str-chat__channel-preview {
-  --channel-name-height: 1.25rem;
   @include utils.component-layer-overrides('channel-preview');
 
   &--active,
@@ -74,24 +70,18 @@
     background-color: var(--str-chat__channel-preview-hover-background-color);
   }
 
-  .str-chat__channel-preview-unread-badge {
-    @include utils.component-layer-overrides('channel-preview-unread-badge');
-    font-size: 0.75rem;
-    line-height: 0.44rem;
-    font-weight: 700;
-  }
+  .str-chat__channel-preview-end-first-row {
+    font: var(--str-chat__subtitle-medium-text);
 
-  .str-chat__channel-preview-messenger--name {
-    font-size: 1rem;
-    line-height: var(--channel-name-height);
-    font-weight: 500;
+    .str-chat__channel-preview-unread-badge {
+      @include utils.component-layer-overrides('channel-preview-unread-badge');
+      font-size: 80%;
+    }
   }
 
   .str-chat__channel-preview-messenger--last-message {
-    font-size: 0.875rem;
-    line-height: 1rem;
+    font: var(--str-chat__body-text);
     color: var(--str-chat__channel-preview-latest-message-secondary-color);
-    font-weight: 400;
   }
 
   &--active,

--- a/src/v2/styles/EditMessageForm/EditMessageForm-theme.scss
+++ b/src/v2/styles/EditMessageForm/EditMessageForm-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__edit-message-modal-button-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__edit-message-modal-button-border-radius: none;
 
@@ -37,9 +34,7 @@
     .str-chat__edit-message-cancel,
     .str-chat__edit-message-send {
       @include utils.component-layer-overrides('edit-message-modal-button');
-      font-size: 0.875rem;
-      line-height: 1rem;
-      font-weight: 500;
+      font: var(--str-chat__body-medium-text);
     }
 
     .str-chat__edit-message-cancel {

--- a/src/v2/styles/Message/Message-theme.scss
+++ b/src/v2/styles/Message/Message-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__message-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__message-border-radius: none;
 
@@ -58,9 +55,6 @@
   /* The background color used if a message option is hovered */
   --str-chat__message-options-active-color: var(--str-chat__primary-color);
 
-  /* The font used in the message bubble */
-  --str-chat__message-bubble-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the message bubble */
   --str-chat__message-bubble-border-radius: var(--str-chat__border-radius-md);
 
@@ -91,9 +85,6 @@
   /* Box shadow applied to the message bubble */
   --str-chat__message-bubble-box-shadow: none;
 
-  /* The font used in a deleted message */
-  --str-chat__deleted-message-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of a deleted message */
   --str-chat__deleted-message-border-radius: var(--str-chat__border-radius-md);
 
@@ -118,9 +109,6 @@
   /* Box shadow applied to a deleted message */
   --str-chat__deleted-message-box-shadow: none;
 
-  /* The font used in a system message */
-  --str-chat__system-message-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of a system message */
   --str-chat__system-message-border-radius: 0;
 
@@ -144,12 +132,6 @@
 
   /* Box shadow applied to a system message */
   --str-chat__system-message-box-shadow: none;
-
-  /* The font used in a deleted message */
-  --str-chat__date-separator-font-family: var(--str-chat__font-family);
-
-  /* Font weight of text in a date separator*/
-  --str-chat__date-separator-font-weight: 700;
 
   /* Text color in a date separator*/
   --str-chat__date-separator-color: var(--str-chat__text-low-emphasis-color);
@@ -181,13 +163,12 @@
 
 .str-chat__message--system {
   @include utils.component-layer-overrides('system-message');
-  font-size: 0.75rem;
-  line-height: 1rem;
+  font: var(--str-chat__caption-text);
 }
 
 .str-chat__date-separator {
   @include utils.component-layer-overrides('date-separator');
-  font-size: 14px;
+  font: var(--str-chat__body-text);
 
   &-line {
     background-color: var(--str-chat__date-separator-line-color);
@@ -196,7 +177,6 @@
 }
 
 .str-chat__message {
-  $message-text-font-size: 0.9375rem;
   @include utils.component-layer-overrides('message');
 
   a {
@@ -206,12 +186,12 @@
 
   .str-chat__message-bubble {
     @include utils.component-layer-overrides('message-bubble');
-    font-size: $message-text-font-size;
+    font: var(--str-chat__body2-text);
   }
 
   .str-chat__message--deleted-inner {
     @include utils.component-layer-overrides('deleted-message');
-    font-size: $message-text-font-size;
+    font: var(--str-chat__body2-text);
   }
 
   &.str-chat__message--me .str-chat__message-bubble {
@@ -248,18 +228,16 @@
 
   .str-chat__message-metadata {
     color: var(--str-chat__message-secondary-color);
-    font-size: 0.75rem;
-    line-height: 1rem;
+    font: var(--str-chat__caption-text);
 
     .str-chat__message-sender-name {
-      font-weight: 500;
+      font: var(--str-chat__caption-medium-text);
     }
   }
 
   .str-chat__message-status {
     color: var(--str-chat__message-status-color);
-    font-size: 0.875rem;
-    line-height: 1.05rem;
+    font: var(--str-chat__body-text);
 
     svg {
       path {
@@ -272,16 +250,14 @@
     button {
       border: none;
       background-color: transparent;
-      font-size: 0.875rem;
-      line-height: 1rem;
+      font: var(--str-chat__body-medium-text);
       color: var(--str-chat__message-replies-count-color);
-      font-weight: 500;
     }
   }
 
   .str-chat__message--error-message {
     color: var(--str-chat__message-error-message-color);
-    font-size: 80%;
+    font: var(--str-chat__caption-text);
   }
 
   .str-chat__message-error-icon {

--- a/src/v2/styles/MessageActionsBox/MessageActionsBox-theme.scss
+++ b/src/v2/styles/MessageActionsBox/MessageActionsBox-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__message-actions-box-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__message-actions-box-border-radius: var(--str-chat__border-radius-sm);
 
@@ -27,9 +24,6 @@
 
   /* Box shadow applied to the component */
   --str-chat__message-actions-box-box-shadow: 0 0 8px var(--str-chat__box-shadow-color);
-
-  /* The font used in an item in the message actions box */
-  --str-chat__message-actions-box-item-font-family: var(--str-chat__font-family);
 
   /* The border radius used for the borders of an item in the message actions box */
   --str-chat__message-actions-box-item-border-radius: 0;
@@ -66,8 +60,7 @@
 
   .str-chat__message-actions-list-item-button {
     @include utils.component-layer-overrides('message-actions-box-item');
-    font-size: 1rem;
-    line-height: 1.25rem;
+    font: var(--str-chat__subtitle-text);
 
     &:hover {
       background-color: var(--str-chat__message-actions-box-item-hover-background-color);

--- a/src/v2/styles/MessageInput/MessageInput-theme.scss
+++ b/src/v2/styles/MessageInput/MessageInput-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__message-input-font-family: var(--str-chat__font-family);
-
   /* The border radius of the component */
   --str-chat__message-input-border-radius: 0;
 
@@ -28,9 +25,6 @@
   /* Box shadow applied to the component */
   --str-chat__message-input-box-shadow: none;
 
-  /* The font used in the textarea */
-  --str-chat__message-textarea-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the textarea */
   --str-chat__message-textarea-border-radius: var(--str-chat__border-radius-md);
 
@@ -54,9 +48,6 @@
 
   /* Box shadow applied to the textarea */
   --str-chat__message-textarea-box-shadow: none;
-
-  /* The font used in the send button */
-  --str-chat__message-send-font-family: var(--str-chat__font-family);
 
   /* The border radius used for the borders of the send button */
   --str-chat__message-send-border-radius: var(--str-chat__border-radius-circle);
@@ -88,9 +79,6 @@
   /* The background color of the send button in disabled state */
   --str-chat__message-send-disabled-background-color: transparent;
 
-  /* The font used in the tool buttons of the message input (such as attachment upload button) */
-  --str-chat__message-input-tools-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the tool buttons of the message input (such as attachment upload button) */
   --str-chat__message-input-tools-border-radius: var(--str-chat__border-radius-circle);
 
@@ -117,9 +105,6 @@
 
   /* Thex text color of the message that is displayed when the use can't send messages */
   --str-chat__message-input-not-allowed-color: var(--str-chat__disabled-color);
-
-  /* The font used in the cooldown timer */
-  --str-chat__cooldown-font-family: var(--str-chat__font-family);
 
   /* The border radius used for the borders of the cooldown timer */
   --str-chat__cooldown-border-radius: var(--str-chat__border-radius-circle);
@@ -170,12 +155,10 @@
       resize: none;
       border: none;
       color: var(--str-chat__message-textarea-color);
-      font-family: var(--str-chat__message-textarea-font-family);
       background-color: transparent;
       box-shadow: none;
       outline: none;
-      font-size: 1rem;
-      line-height: 1.25rem;
+      font: var(--str-chat__subtitle-text);
     }
   }
 
@@ -197,22 +180,17 @@
 
   .str-chat__message-input-cooldown {
     @include utils.component-layer-overrides('cooldown');
-    font-size: 1rem;
-    line-height: 1.25rem;
-    font-weight: 500;
+    font: var(--str-chat__subtitle-medium-text);
   }
 
   .str-chat__message-input-not-allowed {
     color: var(--str-chat__message-input-not-allowed-color);
-    font-size: 1rem;
-    line-height: 1.25rem;
+    font: var(--str-chat__subtitle-text);
   }
 
   .str-chat__quoted-message-preview-header {
     .str-chat__quoted-message-reply-to-message {
-      font-size: 1rem;
-      line-height: 1.25rem;
-      font-weight: 500;
+      font: var(--str-chat__subtitle-medium-text);
     }
 
     .str-chat__quoted-message-remove {

--- a/src/v2/styles/MessageList/MessageList-layout.scss
+++ b/src/v2/styles/MessageList/MessageList-layout.scss
@@ -48,7 +48,7 @@
 
   .str-chat__jump-to-latest-unread-count {
     position: absolute;
-    padding: var(--str-chat__spacing-1) var(--str-chat__spacing-2);
+    padding: var(--str-chat__spacing-0_5) var(--str-chat__spacing-2);
     left: 50%;
     transform: translateX(-50%) translateY(-100%);
   }

--- a/src/v2/styles/MessageList/MessageList-theme.scss
+++ b/src/v2/styles/MessageList/MessageList-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__message-list-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__message-list-border-radius: 0;
 
@@ -27,9 +24,6 @@
 
   /* Right (left in RTL layout) border of the component */
   --str-chat__message-list-border-inline-end: none;
-
-  /* The font used in the jump to latest message button */
-  --str-chat__jump-to-latest-message-font-family: var(--str-chat__circle-fab-font-family);
 
   /* The border radius used for the borders of the jump to latest message button */
   --str-chat__jump-to-latest-message-border-radius: var(--str-chat__circle-fab-border-radius);
@@ -91,8 +85,7 @@
 
     .str-chat__thread-start {
       color: var(--str-chat__thread-head-start-color);
-      font-size: 1rem;
-      line-height: 1.25rem;
+      font: var(--str-chat__subtitle-text);
     }
   }
 }
@@ -106,7 +99,7 @@
       background-color: var(--str-chat__jump-to-latest-message-unread-count-background-color);
       color: var(--str-chat__jump-to-latest-message-unread-count-color);
       border-radius: var(--str-chat__jump-to-latest-message-border-radius);
-      font-size: 0.625rem;
+      font: var(--str-chat__caption-text);
     }
   }
 }

--- a/src/v2/styles/MessageList/VirtualMessageList-theme.scss
+++ b/src/v2/styles/MessageList/VirtualMessageList-theme.scss
@@ -2,9 +2,6 @@
 
 /* Only available in React SDK. */
 .str-chat {
-  /* The font used in the component */
-  --str-chat__virtual-list-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__virtual-list-border-radius: 0;
 

--- a/src/v2/styles/MessageReactions/MessageReactions-layout.scss
+++ b/src/v2/styles/MessageReactions/MessageReactions-layout.scss
@@ -15,7 +15,7 @@
     .str-chat__message-reaction {
       display: flex;
       justify-content: center;
-      align-items: baseline;
+      align-items: center;
       padding: var(--str-chat__spacing-1_5);
 
       button {

--- a/src/v2/styles/MessageReactions/MessageReactions-theme.scss
+++ b/src/v2/styles/MessageReactions/MessageReactions-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__message-reactions-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__message-reactions-border-radius: none;
 
@@ -27,9 +24,6 @@
 
   /* Box shadow applied to the component */
   --str-chat__message-reactions-box-shadow: none;
-
-  /* The font used in a message reaction */
-  --str-chat__message-reaction-font-family: var(--str-chat__font-family);
 
   /* The border radius used for the borders of a message reaction */
   --str-chat__message-reaction-border-radius: var(--str-chat__border-radius-xs);
@@ -70,7 +64,7 @@
 
     .str-chat__message-reaction {
       @include utils.component-layer-overrides('message-reaction');
-      font-size: 0.75rem;
+      font: var(--str-chat__caption-text);
 
       &.str-chat__message-reaction-own {
         color: var(--str-chat__own-message-reaction-color);

--- a/src/v2/styles/MessageReactions/MessageReactionsSelector-theme.scss
+++ b/src/v2/styles/MessageReactions/MessageReactionsSelector-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__message-reactions-options-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__message-reactions-options-border-radius: var(--str-chat__border-radius-circle);
 
@@ -29,9 +26,6 @@
 
   /* Box shadow applied to the component */
   --str-chat__message-reactions-options-box-shadow: 0 0 8px var(--str-chat__box-shadow-color);
-
-  /* The font used in the component */
-  --str-chat__message-reactions-option-font-family: var(--str-chat__font-family);
 
   /* The border radius used for the borders of the component */
   --str-chat__message-reactions-option-border-radius: var(--str-chat__border-radius-md);

--- a/src/v2/styles/Modal/Modal-theme.scss
+++ b/src/v2/styles/Modal/Modal-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the content area of the component */
-  --str-chat__modal-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the content area of the component of the content area of the component */
   --str-chat__modal-border-radius: var(--str-chat__border-radius-sm);
 
@@ -64,7 +61,6 @@
     }
   }
 }
-
 
 // stream-chat-react image gallery does not show the modal inner container. It has to be reset to
 // width of its content in order the modal can be closed when clicked on overlay

--- a/src/v2/styles/Notification/MessageNotification-theme.scss
+++ b/src/v2/styles/Notification/MessageNotification-theme.scss
@@ -2,9 +2,6 @@
 
 /* Only available in React SDK. */
 .str-chat {
-  /* The font used in the component */
-  --str-chat__message-notification-font-family: var(--str-chat__font-family);
-
   /* The background color of the component */
   --str-chat__message-notification-background-color: var(--str-chat__primary-color);
 
@@ -32,6 +29,6 @@
 
 .str-chat__message-notification {
   @include utils.component-layer-overrides('message-notification');
-  font-size: 0.75rem;
+  font: var(--str-chat__caption-text);
   cursor: pointer;
 }

--- a/src/v2/styles/Notification/Notification-theme.scss
+++ b/src/v2/styles/Notification/Notification-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__notification-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__notification-border-radius: var(--str-chat__border-radius-sm);
 
@@ -31,6 +28,5 @@
 
 .str-chat__notification {
   @include utils.component-layer-overrides('notification');
-  font-size: 1rem;
-  line-height: 1.35rem;
+  font: var(--str-chat__subtitle-text);
 }

--- a/src/v2/styles/Notification/NotificationList-theme.scss
+++ b/src/v2/styles/Notification/NotificationList-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__notification-list-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__notification-list-border-radius: none;
 

--- a/src/v2/styles/Thread/Thread-theme.scss
+++ b/src/v2/styles/Thread/Thread-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__thread-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__thread-border-radius: 0;
 
@@ -27,9 +24,6 @@
 
   /* Box shadow applied to the component */
   --str-chat__thread-box-shadow: none;
-
-  /* The font used in the thread header */
-  --str-chat__thread-header-font-family: var(--str-chat__font-family);
 
   /* The border radius used for the borders of the thread header */
   --str-chat__thread-header-border-radius: 0;
@@ -67,17 +61,13 @@
 
     .str-chat__thread-header-name,
     .str-chat__thread-header-title {
-      font-size: 1rem;
-      line-height: 1.25rem;
-      font-weight: 500;
+      font: var(--str-chat__subtitle-medium-text);
     }
 
     .str-chat__thread-header-channel-name,
     .str-chat__thread-header-subtitle {
-      font-size: 0.875rem;
-      line-height: 1rem;
+      font: var(--str-chat__body-text);
       color: var(--str-chat__thread-header-info-color);
-      font-weight: 400;
     }
 
     .str-chat__close-thread-button {

--- a/src/v2/styles/Tooltip/Tooltip-theme.scss
+++ b/src/v2/styles/Tooltip/Tooltip-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__tooltip-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__tooltip-border-radius: var(--str-chat__border-radius-xs);
 
@@ -31,8 +28,7 @@
 
 .str-chat__tooltip {
   @include utils.component-layer-overrides('tooltip');
-  font-size: 0.75rem;
-  line-height: 0.875rem;
+  font: var(--str-chat__caption-text);
 
   &::after {
     background-color: var(--str-chat__tooltip-background-color);

--- a/src/v2/styles/TypingIndicator/TypingIndicator-theme.scss
+++ b/src/v2/styles/TypingIndicator/TypingIndicator-theme.scss
@@ -1,9 +1,6 @@
 @use '../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__typing-indicator-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__typing-indicator-border-radius: none;
 

--- a/src/v2/styles/_base.scss
+++ b/src/v2/styles/_base.scss
@@ -2,6 +2,7 @@
   box-sizing: border-box;
 
   * {
+    font-family: var(--str-chat__font-family);
     box-sizing: border-box;
   }
 

--- a/src/v2/styles/_theme-variables.scss
+++ b/src/v2/styles/_theme-variables.scss
@@ -78,6 +78,36 @@
   /* The font used in the chat, by default, we use [preinstalled OS fonts](https://systemfontstack.com/) */
   --str-chat__font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu,
     Cantarell, Helvetica Neue, sans-serif;
+
+  /* The font used for caption texts */
+  --str-chat__caption-text: 0.75rem/1rem var(--str-chat__font-family);
+
+  /* The font used for caption texts with emphasize */
+  --str-chat__caption-medium-text: 500 0.75rem/1rem var(--str-chat__font-family);
+
+  /* The font used for body texts */
+  --str-chat__body-text: 0.875rem/1rem var(--str-chat__font-family);
+
+  /* The font used for body texts with emphasize */
+  --str-chat__body-medium-text: 500 0.875rem/1rem var(--str-chat__font-family);
+
+  /* The font used for body texts */
+  --str-chat__body2-text: 0.9375rem/1rem var(--str-chat__font-family);
+
+  /* The font used for subtitle texts */
+  --str-chat__subtitle-text: 1rem/1.25rem var(--str-chat__font-family);
+
+  /* The font used for subtitle texts with emphasize */
+  --str-chat__subtitle-medium-text: 500 1rem/1.25rem var(--str-chat__font-family);
+
+  /* The font used for subtitle texts */
+  --str-chat__subtitle2-text: 1.25rem/1.5rem var(--str-chat__font-family);
+
+  /* The font used for headline texts */
+  --str-chat__headline-text: 1.5rem/1.5rem var(--str-chat__font-family);
+
+  /* The font used for headline texts */
+  --str-chat__headline2-text: 1.8rem/1.8rem var(--str-chat__font-family);
 }
 
 .str-chat,

--- a/src/v2/styles/_utils.scss
+++ b/src/v2/styles/_utils.scss
@@ -49,7 +49,6 @@
 @mixin component-layer-overrides($component-name, $important: '') {
   background: var(--str-chat__#{$component-name}-background-color) #{$important};
   color: var(--str-chat__#{$component-name}-color) #{$important};
-  font-family: var(--str-chat__#{$component-name}-font-family) #{$important};
   box-shadow: var(--str-chat__#{$component-name}-box-shadow) #{$important};
   border-radius: var(--str-chat__#{$component-name}-border-radius) #{$important};
   border-block-start: var(--str-chat__#{$component-name}-border-block-start) #{$important};
@@ -116,8 +115,7 @@
 }
 
 @mixin empty-theme($component-name) {
-  font-size: 1.5rem;
-  line-height: 1.5rem;
+  font: var(--str-chat__headline-text);
   text-align: center;
 
   svg path {

--- a/src/v2/styles/common/CTAButton/CTAButton-theme.scss
+++ b/src/v2/styles/common/CTAButton/CTAButton-theme.scss
@@ -1,9 +1,6 @@
 @use '../../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__cta-button-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__cta-button-border-radius: var(--str-chat__border-radius-xs);
 
@@ -41,5 +38,5 @@
 .str-chat__cta-button {
   @include utils.component-layer-overrides('cta-button');
   @include utils.cta-button-overrides('cta-button');
-  font-size: 1rem;
+  font: var(--str-chat__subtitle-text);
 }

--- a/src/v2/styles/common/CircleFAButton/CircleFAButton-theme.scss
+++ b/src/v2/styles/common/CircleFAButton/CircleFAButton-theme.scss
@@ -1,9 +1,6 @@
 @use '../../utils';
 
 .str-chat {
-  /* The font used in the component */
-  --str-chat__circle-fab-font-family: var(--str-chat__font-family);
-
   /* The border radius used for the borders of the component */
   --str-chat__circle-fab-border-radius: var(--str-chat__border-radius-circle);
 


### PR DESCRIPTION
### 🎯 Goal

Make font-size and font-weight properties configurable by CSS theme variables

### 🛠 Implementation details

- Used typography classes defined by [Figma](https://www.figma.com/file/oeHiSMDoutuVbJ9WiVyhcG/Chat-Design-Kit-1.5-Android---In-Progress?node-id=10150%3A8)
- Replaced all font-size and font-weight settings by these classes
- Removed font-family component variables as they become unnecessary
- Updated the docs variable parser: Previously the parser only found variable references inside variable declarations. This change includes references from any kind of declarations/CSS rules (without this references to the new font variables didn't appear in the docs)
 
### 🎨 UI Changes

_Add relevant screenshots_
