### PR TITLE
fix: add text-overflow to suggestion list items

### DIFF
--- a/src/v2/styles/Autocomplete/Autocomplete-layout.scss
+++ b/src/v2/styles/Autocomplete/Autocomplete-layout.scss
@@ -47,6 +47,7 @@
   column-gap: var(--str-chat__spacing-2);
 
   .str-chat__user-item--name {
+    @include utils.ellipsis-text;
     width: 100%;
   }
 }
@@ -57,6 +58,7 @@
   column-gap: var(--str-chat__spacing-2);
 
   .str-chat__emoji-item--name {
+    @include utils.ellipsis-text;
     width: 100%;
   }
 }


### PR DESCRIPTION
### 🎯 Goal

Add text-overflow rule to the text of suggestion list items.

### 🎨 UI Changes

![image](https://user-images.githubusercontent.com/43254280/188732580-b75b0336-51e1-4461-9e2b-875aaa7399fa.png)
