### PR TITLE
fix: replace vertical message margins with padding (theme v1)

### DIFF
--- a/src/v1/Attachment.scss
+++ b/src/v1/Attachment.scss
@@ -74,8 +74,7 @@
     width: 100%;
 
     border-radius: var(--border-radius);
-    margin: var(--xs-m) auto var(--xs-m) 0;
-    padding: 0;
+    padding: var(--xs-m) auto var(--xs-m) 0;
   }
 
   /** Let giphies stretch their containers */
@@ -83,10 +82,13 @@
     max-width: unset;
   }
 
+  .str-chat__message-attachment {
+    margin: var(--xs-m) 0 var(--xs-m) auto;
+  }
+
   &--me {
     .str-chat__message-attachment {
       padding-left: 0;
-      margin: var(--xs-m) 0 var(--xs-m) auto;
     }
   }
 }

--- a/src/v1/Message.scss
+++ b/src/v1/Message.scss
@@ -83,7 +83,7 @@
   /* group styling */
   &--top,
   &--single {
-    margin: 24px 0 0;
+    padding-top: calc(var(--md-p)/2);
 
     .str-chat__message {
       &-attachment--img,
@@ -176,7 +176,7 @@
   }
 
   &--bottom {
-    margin: 0 0 24px;
+    padding-bottom: calc(var(--md-p)/2);
 
     .str-chat__message {
       &-attachment--img,
@@ -217,7 +217,7 @@
   }
 
   &--single {
-    margin-bottom: var(--md-m);
+    padding-bottom: calc(var(--md-m)/2);
   }
 
   &--top,
@@ -233,16 +233,14 @@
     .str-chat__message {
       &-text {
         &-inner {
-          border-radius: var(--border-radius) var(--border-radius) var(--border-radius)
-            calc(var(--border-radius-sm) / 2);
+          border-radius: var(--border-radius) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
         }
       }
 
       &--me {
         .str-chat__message-text {
           &-inner {
-            border-radius: var(--border-radius) var(--border-radius)
-              calc(var(--border-radius-sm) / 2) var(--border-radius);
+            border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2) var(--border-radius);
           }
         }
       }
@@ -253,12 +251,10 @@
     .str-chat__message {
       &-text {
         &-inner {
-          border-radius: var(--border-radius) var(--border-radius) var(--border-radius)
-            calc(var(--border-radius-sm) / 2);
+          border-radius: var(--border-radius) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
 
           &--has-attachment {
-            border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius)
-              var(--border-radius) calc(var(--border-radius-sm) / 2);
+            border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
           }
         }
       }
@@ -266,12 +262,10 @@
       &--me {
         .str-chat__message-text {
           &-inner {
-            border-radius: var(--border-radius) var(--border-radius)
-              calc(var(--border-radius-sm) / 2) var(--border-radius);
+            border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2) var(--border-radius);
 
             &--has-attachment {
-              border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2)
-                calc(var(--border-radius-sm) / 2) var(--border-radius);
+              border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2) calc(var(--border-radius-sm) / 2) var(--border-radius);
             }
           }
         }
@@ -284,16 +278,14 @@
     .str-chat__message {
       &-text {
         &-inner {
-          border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius)
-            calc(var(--border-radius-sm) / 2);
+          border-radius: calc(var(--border-radius-sm) / 2) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2);
         }
       }
 
       &--me {
         .str-chat__message-text {
           &-inner {
-            border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2)
-              calc(var(--border-radius-sm) / 2) var(--border-radius);
+            border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2) calc(var(--border-radius-sm) / 2) var(--border-radius);
 
             &--has-attachment {
               margin: 0;
@@ -304,8 +296,7 @@
         .str-chat__message-attachment-card {
           margin: 0;
           padding: 0;
-          border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2)
-            calc(var(--border-radius-sm) / 2) var(--border-radius);
+          border-radius: var(--border-radius) calc(var(--border-radius-sm) / 2) calc(var(--border-radius-sm) / 2) var(--border-radius);
         }
       }
     }
@@ -319,7 +310,8 @@
   align-items: flex-end;
   padding: 0;
   position: relative;
-  margin: calc(var(--xxs-m) / 2) 0;
+  padding-top: var(--xxs-p);
+  padding-bottom: var(--xxs-p);
   width: 100%;
   transition: background-color 0.5s ease-out;
 
@@ -481,7 +473,6 @@
   /* me */
   &--me {
     display: inline-flex;
-    margin: var(--xxs-m) 0;
     justify-content: flex-end;
 
     .str-chat__message {
@@ -566,7 +557,7 @@
   }
 
   &--with-reactions {
-    margin-top: var(--md-m);
+    padding-top: var(--md-p);
   }
 
   &--highlighted {
@@ -595,20 +586,17 @@
       .str-chat {
         &__message,
         &__message--me {
-          margin: calc(var(--xxs-m) / 2) 0;
 
           &--with-reactions {
-            margin-top: var(--lg-m);
+            padding-top: var(--lg-p);
           }
         }
 
         &__message-attachment--image {
-          margin: calc(var(--xxs-m) / 2) 0;
           max-width: 480px;
         }
 
         &__message-attachment--card {
-          margin: calc(var(--xxs-m) / 2) 0;
           line-height: normal;
         }
 
@@ -962,7 +950,6 @@
   }
 
   .str-chat__message-attachment--file {
-    margin: 0;
     background: var(--white);
     border-color: transparent;
     border: 1px solid var(--grey-gainsboro);

--- a/src/v1/Message.scss
+++ b/src/v1/Message.scss
@@ -586,7 +586,6 @@
       .str-chat {
         &__message,
         &__message--me {
-
           &--with-reactions {
             padding-top: var(--lg-p);
           }

--- a/src/v1/MessageCommerce.scss
+++ b/src/v1/MessageCommerce.scss
@@ -176,7 +176,7 @@
   }
 
   &--with-reactions {
-    margin-top: 30px;
+    padding-top: 30px;
 
     .str-chat__message-commerce__actions__action--reactions {
       display: none;

--- a/src/v1/Thread.scss
+++ b/src/v1/Thread.scss
@@ -10,11 +10,48 @@
   flex-direction: column;
   padding-top: 0;
 
-  .str-chat__thread-container {
-    height: 100%;
+  .str-chat__virtual-list .str-chat__virtual-list-message-wrapper {
+    padding-left: var(--md-p);
+    padding-right: var(--md-p);
+  }
+
+  &.str-chat__thread-container {
+    max-height: 100%;
     display: flex;
     flex-direction: column;
     width: 100%;
+
+    .str-chat__parent-message-li {
+      .str-chat__message {
+        padding-left: var(--md-p);
+        padding-right: var(--md-p);
+
+        .str-chat__message-inner {
+          min-width: 0;
+        }
+
+        .str-chat__message-attachment--image,
+        .str-chat__message-attachment-card {
+          border-radius: var(--border-radius) var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2) ;
+        }
+      }
+
+      .str-chat__message--me {
+        .str-chat__message-attachment--img,
+        .str-chat__message-attachment-card {
+          border-radius: var(--border-radius) var(--border-radius) calc(var(--border-radius-sm) / 2) var(--border-radius);
+        }
+      }
+
+      .str-chat__message--with-reactions {
+        padding-top: var(--xl-p);
+      }
+
+      .str-chat__message:not(.str-chat__message--has-attachment) {
+        padding-top: var(--xs-p);
+      }
+
+    }
   }
 
   &--full {

--- a/src/v1/VirtualMessage.scss
+++ b/src/v1/VirtualMessage.scss
@@ -3,11 +3,11 @@
   font-size: 0;
 
   .str-chat__virtual-list-message-wrapper {
-    padding: 1px var(--xl-p);
+    padding-left: var(--xl-p);
+    padding-right: var(--xl-p);
     width: 100%;
 
     .str-chat__message-simple {
-      padding-bottom: var(--sm-p);
 
       &.str-chat__virtual-message__wrapper--first {
         padding-bottom: 0;
@@ -40,7 +40,6 @@
 
       &.str-chat__virtual-message__wrapper--group {
         align-items: center;
-        padding-bottom: 0;
         padding-left: var(--xl-p);
 
         &.str-chat__message-simple--me {
@@ -254,7 +253,6 @@
 }
 
 .str-chat__virtual-message__wrapper--group {
-  padding-top: 0;
 
   > .str-chat__avatar {
     display: none;

--- a/src/v1/VirtualMessage.scss
+++ b/src/v1/VirtualMessage.scss
@@ -8,7 +8,6 @@
     width: 100%;
 
     .str-chat__message-simple {
-
       &.str-chat__virtual-message__wrapper--first {
         padding-bottom: 0;
         padding-left: var(--xl-p);
@@ -253,7 +252,6 @@
 }
 
 .str-chat__virtual-message__wrapper--group {
-
   > .str-chat__avatar {
     display: none;
   }


### PR DESCRIPTION
### 🎯 Goal

Fix the erratic scroll issue caused by vertical margins around messages in `VirtualizedMessageList`. Replace all message margins with padding in vertical axis. The goal is to keep the message spacing same:

1. in grouped and non-grouped setting (virtualized msg list)
2. between virtualized and non-virtualized message lists
3. taking into consideration messages with and without attachments
4. messages in main message list and in thread

Additionally the parent message alignment was fixed for virtualized thread.

### 🛠 Implementation details

Paddings and margins were combined around the messages and so the margin height was added to padding if it existed.

### 🎨 Demo

[adding_messages_VML.webm](https://user-images.githubusercontent.com/32706194/193301372-bc73e539-7729-4943-a065-01b39345c333.webm)





