### PR TITLE
fix: virtualized thread height (theme v2)

### DIFF
--- a/src/v2/styles/MessageList/MessageList-layout.scss
+++ b/src/v2/styles/MessageList/MessageList-layout.scss
@@ -32,11 +32,8 @@
 
     .str-chat__thread-start {
       text-align: start;
+      padding-top: var(--str-chat__spacing-3);
     }
-  }
-
-  .str-chat__parent-message-li .str-chat__thread-start {
-    padding-top: var(--str-chat__spacing-3);
   }
 }
 

--- a/src/v2/styles/MessageList/VirtualizedMessageList-layout.scss
+++ b/src/v2/styles/MessageList/VirtualizedMessageList-layout.scss
@@ -14,6 +14,15 @@
     @include utils.message-list-spacing;
   }
 
+  .str-chat__parent-message-li {
+    padding-block-end: var(--str-chat__spacing-4);
+
+    .str-chat__thread-start {
+      text-align: start;
+      padding-top: var(--str-chat__spacing-3);
+    }
+  }
+
   // conditionally showing the header displaces items when prepending.
   // a simple workaround is to make the loading indicator an overlay.
   &__loading {
@@ -40,5 +49,17 @@
 
   .str-chat__virtual-list-message-wrapper {
     padding-block-end: var(--str-chat__spacing-0_5);
+  }
+}
+
+
+.str-chat__thread--virtualized {
+  .str-chat__main-panel-inner {
+    height: 100%;
+
+    // the first message in virtualized thread has to be separated from the top by padding, not margin
+    .str-chat__virtual-list-message-wrapper:first-of-type {
+      padding-block-start: var(--str-chat__spacing-4);
+    }
   }
 }

--- a/src/v2/styles/MessageList/VirtualizedMessageList-theme.scss
+++ b/src/v2/styles/MessageList/VirtualizedMessageList-theme.scss
@@ -29,4 +29,13 @@
 
 .str-chat__virtual-list {
   @include utils.component-layer-overrides('virtual-list');
+
+  .str-chat__parent-message-li {
+    border-block-end: 1px solid var(--str-chat__thread-head-start-border-block-end-color);
+
+    .str-chat__thread-start {
+      color: var(--str-chat__thread-head-start-color);
+      font: var(--str-chat__subtitle-text);
+    }
+  }
 }


### PR DESCRIPTION
### 🎯 Goal

Fix the bug, when the virtualized message list had 0 height in `Thread`.

### 🛠 Implementation details

Besides the height fix, also missing thread start styling has been applied in Thread's virtualized message list.

### 🎨 UI Changes


<details><summary>Non-virtualized thread</summary>

![image](https://user-images.githubusercontent.com/32706194/193786275-0160f5f3-4359-41b6-8c85-e84c73cef5b1.png)

</details>

<details><summary>Fixed virtualized thread</summary>

![image](https://user-images.githubusercontent.com/32706194/193788076-c852400d-cefd-47a5-9293-dee544b04c54.png)

</details>
