### PR TITLE
fix: fix collapsed audio widget in virtualized message list

### DIFF
--- a/src/v1/Audio.scss
+++ b/src/v1/Audio.scss
@@ -67,6 +67,7 @@
       margin: 0;
       padding: 0;
       line-height: 1;
+      font-size: var(--md-font);
     }
 
     &--subtitle {


### PR DESCRIPTION
### 🎯 Goal

Make the audio widget in theme v1 look the same for both virtualized and non-virtualized message list. In virtualized message list the widget was absolutely collapsed.

### 🛠 Implementation details

Override `font-size` of the audio title element.

### 🎨 UI Changes

<details><summary>bug</summary>

![image](https://user-images.githubusercontent.com/32706194/193792560-f7e342ed-df78-40f0-85db-3b25c71ceaa0.png)

</details>

<details><summary>fixed</summary>

![image](https://user-images.githubusercontent.com/32706194/193792272-4224c98e-f6c8-4a78-9567-a436db3ffd75.png)

</details>
