### PR TITLE
fix: avoid popper tooltip text from overflowing

### DIFF
--- a/src/v2/styles/Tooltip/Tooltip-layout.scss
+++ b/src/v2/styles/Tooltip/Tooltip-layout.scss
@@ -4,6 +4,6 @@
   display: flex;
   padding: var(--str-chat__spacing-2);
   z-index: 1;
-  word-break: normal;
   max-width: calc(var(--str-chat__spacing-px) * 150);
+  width: max-content;
 }


### PR DESCRIPTION
### 🎯 Goal

Avoid popper tooltip from text from overflowing


### 🎨 UI Changes

**Bug**

![image](https://user-images.githubusercontent.com/32706194/194218769-07dd4a74-783e-4728-932e-04dcd3c424af.png)

**Fix**

![image](https://user-images.githubusercontent.com/32706194/194218820-722c1532-fff8-4126-905e-7de23bfdff2c.png)

