### PR TITLE
feat: adapt channel list for infinite scroll (React only)

### DIFF
--- a/src/v1/ChannelList.scss
+++ b/src/v1/ChannelList.scss
@@ -125,3 +125,17 @@
     }
   }
 }
+
+.str-chat__channel-list.str-chat__channel-list-react {
+  overflow: hidden;
+
+  .str-chat__channel-list-messenger-react {
+    overflow: hidden;
+    padding-bottom: var(--sm-p);
+
+    .str-chat__channel-list-messenger-react__main {
+      overflow-y: auto;
+      height: 100%;
+    }
+  }
+}

--- a/src/v1/ChannelSearch.scss
+++ b/src/v1/ChannelSearch.scss
@@ -1,7 +1,7 @@
 .str-chat__channel-search {
   --channel-search-input-height: 30px;
 
-  padding: var(--md-p) var(--md-p) 0;
+  padding: var(--md-p);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/v1/ChannelSearch.scss
+++ b/src/v1/ChannelSearch.scss
@@ -3,12 +3,13 @@
 
   padding: var(--md-p) var(--md-p) 0;
   display: flex;
+  flex-direction: column;
   align-items: center;
   position: relative;
   background: var(--grey-gainsboro);
 
   input {
-    flex: 1;
+    width: 100%;
     background: var(--grey-whisper);
     border: 1px solid transparent;
     outline: none;
@@ -31,9 +32,7 @@
   }
 
   &-container {
-    position: absolute;
-    width: 300px;
-    z-index: 2;
+
     padding: 8px;
 
     &-searching {
@@ -69,7 +68,10 @@
   &-container.popup {
     border-radius: var(--border-radius-md);
     background: var(--white-smoke);
+    position: absolute;
+    z-index: 2;
     left: 0;
+    right: 0;
     top: calc(var(--channel-search-input-height) + 40px);
     box-shadow: 0 7px 9px 0 var(--border), 0 1px 0 0 var(--border);
     border: 1px solid var(--border);
@@ -86,10 +88,8 @@
   }
 
   &-container.inline {
-    top: 64px;
-    right: 0;
+    width: 100%;
     background: var(--grey-gainsboro);
-    height: calc(100vh - 60px);
 
     .str-chat__channel-search-result {
       &:hover {

--- a/src/v2/styles/ChannelList/ChannelList-layout.scss
+++ b/src/v2/styles/ChannelList/ChannelList-layout.scss
@@ -39,3 +39,17 @@
     display: none;
   }
 }
+
+
+.str-chat__channel-list-react {
+  overflow: hidden;
+
+  .str-chat__channel-list-messenger-react {
+    overflow: hidden;
+    padding-bottom: var(--str-chat__spacing-2_5);
+
+    .str-chat__channel-list-messenger-react__main {
+      overflow-y: auto;
+    }
+  }
+}

--- a/src/v2/styles/ChannelSearch/ChannelSearch-layout.scss
+++ b/src/v2/styles/ChannelSearch/ChannelSearch-layout.scss
@@ -1,71 +1,88 @@
 @use '../utils';
 
-.str-chat__channel-search-bar {
-  @include utils.flex-row-center;
-  padding: var(--str-chat__spacing-2_5);
+.str-chat__channel-search {
+  position: relative;
 
-  .str-chat__channel-search-bar-button {
-    @include utils.button-reset;
-    width: calc(var(--str-chat__spacing-px) * 40);
-    height: calc(var(--str-chat__spacing-px) * 40);
+  .str-chat__channel-search-bar {
+    @include utils.flex-row-center;
     padding: var(--str-chat__spacing-2_5);
-    cursor: pointer;
-  }
 
-  .str-chat__channel-search-input--wrapper {
-    display: flex;
-    align-items: center;
-    flex: 1;
-    padding: var(--str-chat__spacing-2_5);
-    min-width: 0;
-
-    .str-chat__channel-search-input--icon,
-    .str-chat__channel-search-input--clear-button {
-      display: inline-flex;
-      padding: 0 var(--str-chat__spacing-2_5);
+    .str-chat__channel-search-bar-button {
+      @include utils.button-reset;
+      width: calc(var(--str-chat__spacing-px) * 40);
+      height: calc(var(--str-chat__spacing-px) * 40);
+      padding: var(--str-chat__spacing-2_5);
+      cursor: pointer;
     }
 
-    .str-chat__channel-search-input--clear-button {
-      @include utils.button-reset;
-      cursor: pointer;
+    .str-chat__channel-search-input--wrapper {
+      display: flex;
+      align-items: center;
+      flex: 1;
+      padding: var(--str-chat__spacing-2_5);
+      min-width: 0;
 
-      &:disabled {
-        cursor: default;
+      .str-chat__channel-search-input--icon,
+      .str-chat__channel-search-input--clear-button {
+        display: inline-flex;
+        padding: 0 var(--str-chat__spacing-2_5);
+      }
+
+      .str-chat__channel-search-input--clear-button {
+        @include utils.button-reset;
+        cursor: pointer;
+
+        &:disabled {
+          cursor: default;
+        }
+      }
+
+      input {
+        flex: 1;
+        min-width: 0;
+      }
+    }
+  }
+
+  .str-chat__channel-search-container-searching {
+    width: 100%;
+    padding: var(--str-chat__spacing-5) var(--str-chat__spacing-4);
+  }
+
+  .str-chat__channel-search-results-header {
+    width: 100%;
+    padding: var(--str-chat__spacing-5) var(--str-chat__spacing-4);
+  }
+
+
+  .str-chat__channel-search-result-list {
+    &.popup {
+      position: absolute;
+      left: 0;
+      right: 0;
+    }
+
+    .str-chat__channel-search-container-empty {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      width: 100%;
+      padding: var(--str-chat__spacing-5) var(--str-chat__spacing-4);
+
+      svg {
+        height: calc(var(--str-chat__spacing-px) * 90 + var(--str-chat__spacing-20));
+        width: calc(var(--str-chat__spacing-px) * 90);
+        padding: var(--str-chat__spacing-10) 0;
       }
     }
 
-    input {
-      flex: 1;
-      min-width: 0;
+    .str-chat__channel-search-result {
+      @include utils.button-reset;
+      display: flex;
+      align-items: center;
+      width: 100%;
+      column-gap: var(--str-chat__spacing-2);
+      padding: var(--str-chat__spacing-3) var(--str-chat__spacing-2);
     }
-  }
-}
-
-.str-chat__channel-search-results-header {
-  width: 100%;
-  padding: var(--str-chat__spacing-5) var(--str-chat__spacing-4);
-}
-
-.str-chat__channel-search-result-list {
-  .str-chat__channel-search-container-empty {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    svg {
-      height: calc(var(--str-chat__spacing-px) * 90 + var(--str-chat__spacing-20));
-      width: calc(var(--str-chat__spacing-px) * 90);
-      padding: var(--str-chat__spacing-10) 0;
-    }
-  }
-
-  .str-chat__channel-search-result {
-    @include utils.button-reset;
-    display: flex;
-    align-items: center;
-    width: 100%;
-    column-gap: var(--str-chat__spacing-2);
-    padding: var(--str-chat__spacing-3) var(--str-chat__spacing-2);
   }
 }

--- a/src/v2/styles/ChannelSearch/ChannelSearch-theme.scss
+++ b/src/v2/styles/ChannelSearch/ChannelSearch-theme.scss
@@ -89,6 +89,25 @@
     --str-chat__secondary-surface-color
   );
 
+  --str-chat__channel-search-result-list-color: var(--str-chat__text-color);
+
+  --str-chat__channel-search-result-list-background-color: var(--str-chat__secondary-background-color);
+
+  /* Top border of the component  */
+  --str-chat__channel-search-result-list-border-block-start: none;
+
+  /* Bottom border of the component */
+  --str-chat__channel-search-result-list-border-block-end: none;
+
+  /* Left (right in RTL layout) border of the component */
+  --str-chat__channel-search-result-list-border-inline-start: none;
+
+  /* Right (left in RTL layout) border of the component */
+  --str-chat__channel-search-result-list-border-inline-end: none;
+
+  /* Box shadow applied to the component */
+  --str-chat__channel-search-result-list-popup-box-shadow: 0 4px 4px var(--str-chat__box-shadow-color);
+
   /* The font color used in the search results header  */
   --str-chat__channel-search-results-header-color: var(--str-chat__text-low-emphasis-color);
 
@@ -107,6 +126,25 @@
 
   /* Right (left in RTL layout) border of the component */
   --str-chat__channel-search-results-header-border-inline-end: none;
+
+  /* The font color used in the search results loading indicator  */
+  --str-chat__channel-search-results-loading-indicator-color: var(--str-chat__text-low-emphasis-color);
+
+  /* The background color used in the search results loading indicator  */
+  --str-chat__channel-search-results-loading-indicator-background-color: var(--str-chat__background-color);
+
+  /* Top border of the component  */
+  --str-chat__channel-search-results-loading-indicator-border-block-start: none;
+
+  /* Bottom border of the component */
+  --str-chat__channel-search-results-loading-indicator-border-block-end: var(--str-chat__surface-color) 1px
+    solid;
+
+  /* Left (right in RTL layout) border of the component */
+  --str-chat__channel-search-results-loading-indicator-border-inline-start: none;
+
+  /* Right (left in RTL layout) border of the component */
+  --str-chat__channel-search-results-loading-indicator-border-inline-end: none;
 
   /* The font color used in the empty search results indicator  */
   --str-chat__channel-search-results-empty-color: var(--str-chat__text-low-emphasis-color);
@@ -162,6 +200,16 @@
 }
 
 .str-chat__channel-search-result-list {
+  @include utils.component-layer-overrides('channel-search-result-list');
+
+  &.popup {
+    box-shadow: var(--str-chat__channel-search-result-list-popup-box-shadow);
+  }
+
+  .str-chat__channel-search-container-searching {
+    @include utils.component-layer-overrides('channel-search-results-loading-indicator');
+  }
+
   .str-chat__channel-search-container-empty {
     @include utils.component-layer-overrides('channel-search-results-empty');
     font: var(--str-chat__subtitle2-medium-text);


### PR DESCRIPTION
### 🎯 Goal

Change the scroll container from `str-chat__channel-list` to `str-chat__channel-list-messenger__main`. That would allow the infinite scroll component wrapping the actual channel preview listing to react to the scroll events.

Besides that, the channel search result list bugs are fixed both in theme v1 and v2.

Related to https://github.com/GetStream/stream-chat-react/pull/1803

### 🎨 UI Changes

**Channel search result list bugs (theme v1):**

<details><summary>Inline results</summary>

**Bug:**

![image](https://user-images.githubusercontent.com/32706194/194543716-ddebaae6-957e-4f4b-a836-fc8f4785e59b.png)

**Fix:**

![image](https://user-images.githubusercontent.com/32706194/194545265-b4e2403f-7c80-4c12-932b-fd247ac409cd.png)


</details>

<details><summary>Popup results</summary>

**Bug:**

![image](https://user-images.githubusercontent.com/32706194/194543891-5b3b8fe3-8664-4cec-ae7e-4811a6836db1.png)


**Fix:**

![image](https://user-images.githubusercontent.com/32706194/194545077-d12f1443-c573-455c-9d2c-84a942f1a894.png)


</details>

**Channel search result list bugs (theme v2):**

<details><summary>Popup results</summary>

**Bug (the results are not floating above the channel list):**


![image](https://user-images.githubusercontent.com/32706194/194544353-48da96a1-0976-43c2-a649-9d306358e324.png)

**Fix:**

![image](https://user-images.githubusercontent.com/32706194/194544848-48e149cd-e8dd-423a-bc5a-8b7d0e4e4095.png)


</details>
