### PR TITLE
v3.7.1

### DIFF
--- a/src/v2/styles/AttachmentList/AttachmentList-layout.scss
+++ b/src/v2/styles/AttachmentList/AttachmentList-layout.scss
@@ -94,20 +94,18 @@
   }
 
   // Images uploaded from files
-  .str-chat__message-attachment--image:not(.str-chat__message-attachment--card) {
-    img {
-      @include utils.clamped-height-from-original-image-dimensions(
-        '--str-chat__attachment-max-width',
-        '--str-chat__attachment-max-width'
-      );
+  .str-chat__message-attachment--image:not(.str-chat__message-attachment--card) > img {
+    @include utils.clamped-height-from-original-image-dimensions(
+      '--str-chat__attachment-max-width',
+      '--str-chat__attachment-max-width'
+    );
 
-      // CDN resize requires max-width and height/max-height to be present on this element
-      max-width: var(--str-chat__attachment-max-width);
-      max-height: var(--str-chat__attachment-max-width);
-      object-fit: cover;
-      width: 100%;
-      cursor: zoom-in;
-    }
+    // CDN resize requires max-width and height/max-height to be present on this element
+    max-width: var(--str-chat__attachment-max-width);
+    max-height: var(--str-chat__attachment-max-width);
+    object-fit: cover;
+    width: 100%;
+    cursor: zoom-in;
   }
 
   // Video files: uploaded from files and scraped


### PR DESCRIPTION
* fix: add immediate-child selector to prevent gallery targeting (#210)