### PR TITLE
fix: Add padding to first message in message list

### DIFF
--- a/src/v2/styles/MessageList/MessageList-layout.scss
+++ b/src/v2/styles/MessageList/MessageList-layout.scss
@@ -56,3 +56,11 @@
     height: auto;
   }
 }
+
+.str-chat__main-panel {
+  .str-chat__ul {
+    .str-chat__li:first-of-type {
+      padding-top: 4.5rem;
+    }
+  }
+}


### PR DESCRIPTION
### 🎯 Goal

Add padding to the first message in the message list to solve the problem where reactions aren't properly visible. Tested with Angular and React SDK.

### 🛠 Implementation details

Only added this to the message list. I wasn't sure if the changing height of the messages wouldn't cause problems inside the virtualized list.

### 🎨 UI Changes

Before:
![Screenshot 2023-01-19 at 11 47 54](https://user-images.githubusercontent.com/6690098/213450690-fa82c498-5942-4642-9977-7f23b6a6bbe0.png)

After:
![Screenshot 2023-01-19 at 13 39 52](https://user-images.githubusercontent.com/6690098/213450741-59629115-0d46-4212-af8f-e31a96245eea.png)



