### PR TITLE
fix: add support for flag emoji replacements for Windows in theming v2

### DIFF
--- a/src/v2/styles/_emoji-replacement.scss
+++ b/src/v2/styles/_emoji-replacement.scss
@@ -1,0 +1,40 @@
+/* declare a font faces for our Emoji Replacement font, based on the default font used by Stream Chat React */
+$assetsPath: '../../assets';
+$emoji-flag-unicode-range: U+1F1E6-1F1FF;
+
+/* png based woff for most browsers */
+@font-face {
+  font-family: ReplaceFlagEmojiPNG;
+  src: url('#{$assetsPath}/NotoColorEmoji-flags.woff2') format('woff2');
+  /* using the unicode-range attribute to limit the reach of the Flag Emoji web font to only flags */
+  unicode-range: $emoji-flag-unicode-range;
+}
+
+/* svg based for firefox */
+@font-face {
+  font-family: ReplaceFlagEmojiSVG;
+  src: url('#{$assetsPath}/EmojiOneColor.woff2') format('woff2');
+  unicode-range: $emoji-flag-unicode-range;
+}
+
+.str-chat--windows-flags {
+  .str-chat__textarea__textarea,
+  .str-chat__message-text-inner *,
+  .str-chat__emoji-item--entity,
+  .emoji-mart-emoji-native * {
+    font-family: ReplaceFlagEmojiPNG, var(--str-chat__font-family), sans-serif;
+    font-display: swap;
+  }
+}
+
+@-moz-document url-prefix('') {
+  .str-chat--windows-flags {
+    .str-chat__textarea__textarea,
+    .str-chat__message-text-inner *,
+    .str-chat__emoji-item--entity,
+    .emoji-mart-emoji-native * {
+      font-family: ReplaceFlagEmojiSVG, var(--str-chat__font-family), sans-serif;
+      font-display: swap;
+    }
+  }
+}

--- a/src/v2/styles/index.layout.scss
+++ b/src/v2/styles/index.layout.scss
@@ -1,4 +1,5 @@
 @use 'base';
+@use 'emoji-replacement';
 @use 'global-layout-variables';
 
 @use 'Avatar/Avatar-layout';


### PR DESCRIPTION
### 🎯 Goal

Fix: https://github.com/GetStream/stream-chat-react/issues/1944

Provide replacement for emoji flags in Windows for theming v2. This feature was supported in theming v1, but was not ported to v2.