### PR TITLE
fix: position the TypingIndicator at the bottom of the VirtualizedMessageList

### DIFF
--- a/src/v2/styles/TypingIndicator/TypingIndicator-layout.scss
+++ b/src/v2/styles/TypingIndicator/TypingIndicator-layout.scss
@@ -4,6 +4,10 @@
   position: static !important;
 }
 
+.str-chat__virtual-list .str-chat__typing-indicator {
+  position: static;
+}
+
 .str-chat__typing-indicator {
   padding: var(--str-chat__spacing-1_5);
   display: flex;


### PR DESCRIPTION
### 🎯 Goal

At least align the TypingIndicator to the bottom in the VirtualizedMessageList

Unfortunately the `TypingIndicator` is part of the scrolled list and so if the user scrolls up, the indicator is not visible. However, moving the `TypingIndicator` component out of the VML above `MessageListNotifications` would be a breaking change.

Partially fixes: https://github.com/GetStream/stream-chat-react/issues/1951

### 🎨 UI Changes

Before

<img width="901" alt="image" src="https://user-images.githubusercontent.com/32706194/223272558-424ea164-53db-4bad-8901-8c53f2f369bd.png">


After

<img width="901" alt="image" src="https://user-images.githubusercontent.com/32706194/223272853-8a8f5bae-48c5-43d9-abd6-c9e8bba4ef27.png">
