### PR TITLE
v3.9.1

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,5 @@ _Provide a description of the implementation_
 ### 🎨 UI Changes
 
 _Add relevant screenshots_
+
+Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs

--- a/src/v2/styles/Message/Message-layout.scss
+++ b/src/v2/styles/Message/Message-layout.scss
@@ -250,11 +250,45 @@
   }
 }
 
-.str-chat__li {
-  &:hover {
-    .str-chat__message-options {
-      display: flex;
+// Message options display - default mode: they appear when .str-chat__li is hovered
+.str-chat__ul:not(.str-chat__message-options-in-bubble) {
+  .str-chat__li {
+    &:hover {
+      .str-chat__message-options {
+        display: flex;
+      }
     }
+  }
+
+  .str-chat__li:hover {
+    .str-chat__message--other .str-chat__message-inner {
+      margin-inline-end: 0;
+    }
+  }
+
+  .str-chat__li:hover {
+    .str-chat__message--me .str-chat__message-inner {
+      margin-inline-start: 0;
+    }
+  }
+}
+
+// Message options display - second mode: they appear when .str-chat__message-inner is hovered
+.str-chat__ul.str-chat__message-options-in-bubble {
+  .str-chat__message-inner {
+    &:hover {
+      .str-chat__message-options {
+        display: flex;
+      }
+    }
+  }
+
+  .str-chat__message--other .str-chat__message-inner:hover {
+    margin-inline-end: 0;
+  }
+
+  .str-chat__message--me .str-chat__message-inner:hover {
+    margin-inline-start: 0;
   }
 }
 
@@ -272,20 +306,8 @@
   margin-inline-end: calc(var(--str-chat__message-options-button-size) * 3);
 }
 
-.str-chat__li:hover {
-  .str-chat__message--other .str-chat__message-inner {
-    margin-inline-end: 0;
-  }
-}
-
 .str-chat__message--me .str-chat__message-inner {
   margin-inline-start: calc(var(--str-chat__message-options-button-size) * 3);
-}
-
-.str-chat__li:hover {
-  .str-chat__message--me .str-chat__message-inner {
-    margin-inline-start: 0;
-  }
 }
 
 .str-chat__li--middle,

--- a/src/v2/styles/Message/Message-layout.scss
+++ b/src/v2/styles/Message/Message-layout.scss
@@ -251,7 +251,8 @@
 }
 
 // Message options display - default mode: they appear when .str-chat__li is hovered
-.str-chat__ul:not(.str-chat__message-options-in-bubble) {
+.str-chat__ul:not(.str-chat__message-options-in-bubble),
+.str-chat__virtual-list:not(.str-chat__message-options-in-bubble) {
   .str-chat__li {
     &:hover {
       .str-chat__message-options {
@@ -274,7 +275,8 @@
 }
 
 // Message options display - second mode: they appear when .str-chat__message-inner is hovered
-.str-chat__ul.str-chat__message-options-in-bubble {
+.str-chat__ul.str-chat__message-options-in-bubble,
+.str-chat__virtual-list.str-chat__message-options-in-bubble {
   .str-chat__message-inner {
     &:hover {
       .str-chat__message-options {

--- a/src/v2/styles/TypingIndicator/TypingIndicator-layout.scss
+++ b/src/v2/styles/TypingIndicator/TypingIndicator-layout.scss
@@ -4,6 +4,10 @@
   position: static !important;
 }
 
+.str-chat__virtual-list .str-chat__typing-indicator {
+  position: static;
+}
+
 .str-chat__typing-indicator {
   padding: var(--str-chat__spacing-1_5);
   display: flex;

--- a/src/v2/styles/_emoji-replacement.scss
+++ b/src/v2/styles/_emoji-replacement.scss
@@ -1,0 +1,40 @@
+/* declare a font faces for our Emoji Replacement font, based on the default font used by Stream Chat React */
+$assetsPath: '../../assets';
+$emoji-flag-unicode-range: U+1F1E6-1F1FF;
+
+/* png based woff for most browsers */
+@font-face {
+  font-family: ReplaceFlagEmojiPNG;
+  src: url('#{$assetsPath}/NotoColorEmoji-flags.woff2') format('woff2');
+  /* using the unicode-range attribute to limit the reach of the Flag Emoji web font to only flags */
+  unicode-range: $emoji-flag-unicode-range;
+}
+
+/* svg based for firefox */
+@font-face {
+  font-family: ReplaceFlagEmojiSVG;
+  src: url('#{$assetsPath}/EmojiOneColor.woff2') format('woff2');
+  unicode-range: $emoji-flag-unicode-range;
+}
+
+.str-chat--windows-flags {
+  .str-chat__textarea__textarea,
+  .str-chat__message-text-inner *,
+  .str-chat__emoji-item--entity,
+  .emoji-mart-emoji-native * {
+    font-family: ReplaceFlagEmojiPNG, var(--str-chat__font-family), sans-serif;
+    font-display: swap;
+  }
+}
+
+@-moz-document url-prefix('') {
+  .str-chat--windows-flags {
+    .str-chat__textarea__textarea,
+    .str-chat__message-text-inner *,
+    .str-chat__emoji-item--entity,
+    .emoji-mart-emoji-native * {
+      font-family: ReplaceFlagEmojiSVG, var(--str-chat__font-family), sans-serif;
+      font-display: swap;
+    }
+  }
+}

--- a/src/v2/styles/index.layout.scss
+++ b/src/v2/styles/index.layout.scss
@@ -1,4 +1,5 @@
 @use 'base';
+@use 'emoji-replacement';
 @use 'global-layout-variables';
 
 @use 'Avatar/Avatar-layout';


### PR DESCRIPTION
- fix: Message options doesn't appear in virtualized message list(https://github.com/GetStream/stream-chat-css/pull/219)
- fix: add support for flag emoji replacements for Windows in theming v2 (https://github.com/GetStream/stream-chat-css/pull/220)
- fix: position the TypingIndicator at the bottom of the VirtualizedMessageList (https://github.com/GetStream/stream-chat-css/pull/221)