### PR TITLE
fix: prevent giphy in preview from overflowing in virtualized message list

### DIFF
--- a/src/v1/Card.scss
+++ b/src/v1/Card.scss
@@ -1,3 +1,12 @@
+.str-chat__message-attachment-card:not(.str-chat__message-attachment-card--giphy) {
+  .str-chat__message-attachment-card--header {
+    img {
+      width: inherit;
+      height: inherit;
+    }
+  }
+}
+
 .str-chat__message-attachment-card {
   position: relative;
   background: var(--white);
@@ -12,8 +21,6 @@
     height: 175px;
 
     img {
-      width: inherit;
-      height: inherit;
       object-fit: cover;
     }
   }
@@ -65,6 +72,24 @@
 
   &--giphy &--header {
     height: unset;
+  }
+}
+
+.giphy-preview-message {
+  .str-chat__message-attachment-card--giphy {
+    display: flex;
+    flex-direction: column;
+
+    .str-chat__message-attachment-card--header {
+      display: flex;
+      justify-content: center;
+      background-color: white;
+      
+      .str-chat__message-attachment--img {
+        width: unset;
+      }
+    }
+
   }
 }
 


### PR DESCRIPTION
### 🎯 Goal

Fix the visual bug of overflowing giphy preview. The message action buttons were not visible and shuffling was not possible.

These changes apply only to CSS v1 in VirtualizedMessageList only in stream-chat-react.


### 🎨 UI Changes

**Before (missing message actions)**

![image](https://user-images.githubusercontent.com/32706194/227539923-4dcbc5cb-60d4-4e5b-9c28-6e0c0e9542d9.png)


**After (fixing also image fit)**

<img width="829" alt="Screenshot 2023-03-24 at 13 25 57" src="https://user-images.githubusercontent.com/32706194/227540097-feb6efd3-69ed-4783-8bfa-e40f6576920e.png">

