### PR TITLE
fix(react-sdk): hide main panel on hideOnThread in stylesheet v2

### DIFF
--- a/src/v2/styles/Channel/Channel-layout.scss
+++ b/src/v2/styles/Channel/Channel-layout.scss
@@ -17,6 +17,10 @@
       width: 100%;
       min-width: 0;
     }
+
+    .str-chat__main-panel--hideOnThread {
+      display: none;
+    }
   }
 }
 

--- a/src/v2/styles/Thread/Thread-layout.scss
+++ b/src/v2/styles/Thread/Thread-layout.scss
@@ -42,6 +42,11 @@
   }
 }
 
+.str-chat__main-panel--hideOnThread + .str-chat__thread-container {
+  // occupy the whole space by previously occupied by the main message list container
+  flex: 1;
+}
+
 .str-chat__parent-message-li {
   padding: var(--str-chat__spacing-2);
 }


### PR DESCRIPTION
### 🎯 Goal

Support `-hideOnThread` flag in stylesheet v2 for `stream-chat-react`. When `str-chat__main-panel--hideOnThread` class is present, the main message list should not be displayed and the thread panel should occupy the vacated space.

fix: https://github.com/GetStream/stream-chat-react/issues/2024
