### PR TITLE
feat: Don't apply padding-top hack when date separator is in use

### DIFF
--- a/src/v2/styles/MessageList/MessageList-layout.scss
+++ b/src/v2/styles/MessageList/MessageList-layout.scss
@@ -62,5 +62,9 @@
     .str-chat__li:first-of-type {
       padding-top: 4.5rem;
     }
+
+    .str-chat__li:first-of-type + .str-chat__date-separator {
+      padding-top: inherit;
+    }
   }
 }


### PR DESCRIPTION
### 🎯 Goal

We have a hacky solution for applying `padding-top` to the first message in the list, this is to fix the issue of reactions not displayed properly for the first message. This hack is not necessary if we have a date separator, so this PR turns that of for that cases.

### 🛠 Implementation details

_Provide a description of the implementation_

### 🎨 UI Changes

_Add relevant screenshots_

Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
