### PR TITLE
fix: Padding of first message on date separator

### DIFF
--- a/src/v2/styles/MessageList/MessageList-layout.scss
+++ b/src/v2/styles/MessageList/MessageList-layout.scss
@@ -63,7 +63,7 @@
       padding-top: 4.5rem;
     }
 
-    .str-chat__li:first-of-type + .str-chat__date-separator {
+    .str-chat__date-separator + .str-chat__li:first-of-type {
       padding-top: inherit;
     }
   }


### PR DESCRIPTION
### 🎯 Goal

_Describe why we are making this change_

### 🛠 Implementation details

_Provide a description of the implementation_

### 🎨 UI Changes

_Add relevant screenshots_

Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
