### PR TITLE
fix(react-image-gallery): adjust react-image-gallery class names

### DIFF
--- a/src/v2/styles/vendor/react-image-gallery.scss
+++ b/src/v2/styles/vendor/react-image-gallery.scss
@@ -165,6 +165,8 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
     object-fit: contain;
   }
 
+  &.left,
+  &.right,
   &.image-gallery-thumbnails-left,
   &.image-gallery-thumbnails-right {
     .image-gallery-slide .image-gallery-image {
@@ -176,6 +178,8 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
 .image-gallery-slide-wrapper {
   position: relative;
 
+  &.left,
+  &.right,
   &.image-gallery-thumbnails-left,
   &.image-gallery-thumbnails-right {
     display: inline-block;
@@ -205,6 +209,7 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
   top: 0;
   width: 100%;
 
+  &.center,
   &.image-gallery-center {
     position: relative;
   }

--- a/src/v2/styles/vendor/react-image-gallery.scss
+++ b/src/v2/styles/vendor/react-image-gallery.scss
@@ -165,8 +165,8 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
     object-fit: contain;
   }
 
-  &.left,
-  &.right {
+  &.image-gallery-thumbnails-left,
+  &.image-gallery-thumbnails-right {
     .image-gallery-slide .image-gallery-image {
       max-height: 100vh;
     }
@@ -176,8 +176,8 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
 .image-gallery-slide-wrapper {
   position: relative;
 
-  &.left,
-  &.right {
+  &.image-gallery-thumbnails-left,
+  &.image-gallery-thumbnails-right {
     display: inline-block;
     width: calc(100% - 110px); // 100px + 10px for margin
 
@@ -205,7 +205,7 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
   top: 0;
   width: 100%;
 
-  &.center {
+  &.image-gallery-center {
     position: relative;
   }
 

--- a/src/vendor/react-image-gallery.scss
+++ b/src/vendor/react-image-gallery.scss
@@ -165,6 +165,8 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
     object-fit: contain;
   }
 
+  &.left,
+  &.right,
   &.image-gallery-thumbnails-left,
   &.image-gallery-thumbnails-right {
     .image-gallery-slide .image-gallery-image {
@@ -176,6 +178,8 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
 .image-gallery-slide-wrapper {
   position: relative;
 
+  &.left,
+  &.right,
   &.image-gallery-thumbnails-left,
   &.image-gallery-thumbnails-right {
     display: inline-block;
@@ -205,6 +209,7 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
   top: 0;
   width: 100%;
 
+  &.center,
   &.image-gallery-center {
     position: relative;
   }

--- a/src/vendor/react-image-gallery.scss
+++ b/src/vendor/react-image-gallery.scss
@@ -165,8 +165,8 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
     object-fit: contain;
   }
 
-  &.left,
-  &.right {
+  &.image-gallery-thumbnails-left,
+  &.image-gallery-thumbnails-right {
     .image-gallery-slide .image-gallery-image {
       max-height: 100vh;
     }
@@ -176,8 +176,8 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
 .image-gallery-slide-wrapper {
   position: relative;
 
-  &.left,
-  &.right {
+  &.image-gallery-thumbnails-left,
+  &.image-gallery-thumbnails-right {
     display: inline-block;
     width: calc(100% - 110px); // 100px + 10px for margin
 
@@ -205,7 +205,7 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
   top: 0;
   width: 100%;
 
-  &.center {
+  &.image-gallery-center {
     position: relative;
   }
 


### PR DESCRIPTION
### 🎯 Goal

Package `react-image-gallery` [updated class names](https://github.com/xiaolin/react-image-gallery/pull/692) (released in `1.2.12` as minor version update) it uses internally which in turn broke our gallery component due to the fact that we use [their updated style sheet](https://github.com/GetStream/stream-chat-css/blob/develop/src/v2/styles/vendor/react-image-gallery.scss).

Our package `stream-chat-react` specifies `react-image-gallery` version in `package.json` as `^1.2.7` which means that package managers will install any available version up to `>2.0.0`. Our modified vendor stylesheet works with versions only up to `>1.2.12` which in turn breaks applications which install newer versions of the `react-image-gallery`.