### PR TITLE
fix: make search results scrollable

### DIFF
--- a/src/v2/styles/ChannelSearch/ChannelSearch-layout.scss
+++ b/src/v2/styles/ChannelSearch/ChannelSearch-layout.scss
@@ -2,10 +2,23 @@
 
 .str-chat__channel-search {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  $search-bar-height: 65px;
+
+  &.str-chat__channel-search--with-results.inline {
+    height: 100%;
+  }
+
+  &.inline {
+    min-height: 0;
+  }
 
   .str-chat__channel-search-bar {
     @include utils.flex-row-center;
     padding: var(--str-chat__spacing-2_5);
+    height: $search-bar-height;
 
     .str-chat__channel-search-bar-button {
       @include utils.button-reset;
@@ -56,10 +69,24 @@
 
 
   .str-chat__channel-search-result-list {
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    overflow-x: hidden;
+
+    &.inline {
+      flex: 1;
+    }
+
     &.popup {
       position: absolute;
       left: 0;
       right: 0;
+      top: $search-bar-height;
+      height: 400px;
+      // have to add z-index as since 1.2023 avatar has position relative
+      // and the ones from channel list would show above search results
+      z-index: 1;
     }
 
     .str-chat__channel-search-container-empty {

--- a/src/v2/styles/ChannelSearch/ChannelSearch-layout.scss
+++ b/src/v2/styles/ChannelSearch/ChannelSearch-layout.scss
@@ -1,11 +1,11 @@
 @use '../utils';
 
 .str-chat__channel-search {
+  $search-bar-height: 65px;
   position: relative;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  $search-bar-height: 65px;
 
   &.str-chat__channel-search--with-results.inline {
     height: 100%;


### PR DESCRIPTION
### 🎯 Goal

If the search results overflew the container, it was not possible to scroll them. The adjustments are done to both the inline and popup version of search results. The search bar height is now fixed to match with the absolute popup positioning.