### PR TITLE
fix: namespace the ChannelSearch's root element "inline" and "popup" classes

### DIFF
--- a/src/v2/styles/ChannelSearch/ChannelSearch-layout.scss
+++ b/src/v2/styles/ChannelSearch/ChannelSearch-layout.scss
@@ -7,11 +7,11 @@
   flex-direction: column;
   justify-content: center;
 
-  &.str-chat__channel-search--with-results.inline {
+  &.str-chat__channel-search--with-results.str-chat__channel-search--inline {
     height: 100%;
   }
 
-  &.inline {
+  &.str-chat__channel-search--inline {
     min-height: 0;
   }
 


### PR DESCRIPTION
### 🎯 Goal

Avoid conflicts with integrators' custom rules attached to `inline` class.