### PR TITLE
feat(angular): Only display slash command autocomplete for first char…

### DIFF
--- a/src/v1/MessageInput.scss
+++ b/src/v1/MessageInput.scss
@@ -390,3 +390,9 @@
     top: 6px;
   }
 }
+
+.str-chat__message-textarea-angular-host--slash-commands-hidden {
+  mention-list  {
+    display: none;
+  }
+}

--- a/src/v2/styles/Autocomplete/Autocomplete-layout.scss
+++ b/src/v2/styles/Autocomplete/Autocomplete-layout.scss
@@ -63,3 +63,9 @@
     width: 100%;
   }
 }
+
+.str-chat__message-textarea-angular-host--slash-commands-hidden {
+  mention-list  {
+    display: none;
+  }
+}


### PR DESCRIPTION
…acter

### 🎯 Goal

Angular only feature to fix this issue: closes https://github.com/GetStream/stream-chat-angular/issues/318

React SDK isn't affected
### 🛠 Implementation details

_Provide a description of the implementation_

### 🎨 UI Changes

_Add relevant screenshots_

Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
