### PR TITLE
fix: class name for Angular slash commands hiding

### DIFF
--- a/src/v1/MessageInput.scss
+++ b/src/v1/MessageInput.scss
@@ -391,7 +391,7 @@
   }
 }
 
-.str-chat__message-textarea-angular-host--slash-commands-hidden {
+.str-chat__message-textarea-angular-host--autocomplete-hidden {
   mention-list  {
     display: none;
   }

--- a/src/v2/styles/Autocomplete/Autocomplete-layout.scss
+++ b/src/v2/styles/Autocomplete/Autocomplete-layout.scss
@@ -64,7 +64,7 @@
   }
 }
 
-.str-chat__message-textarea-angular-host--slash-commands-hidden {
+.str-chat__message-textarea-angular-host--autocomplete-hidden {
   mention-list  {
     display: none;
   }


### PR DESCRIPTION
### 🎯 Goal

_Describe why we are making this change_

### 🛠 Implementation details

_Provide a description of the implementation_

### 🎨 UI Changes

_Add relevant screenshots_

Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
