### PR TITLE
fix: remove emoji-replacement from final builds, distribute separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate-docs": "ts-node scripts/generate-docs.ts",
     "replace-docs": "ts-node scripts/replacer.ts",
     "copy": "cp -R src/v2/styles/* dist/v2/scss",
-    "compile-to-css": "sass src/v2/styles/index.scss dist/v2/css/index.css --style compressed && sass src/v2/styles/index.layout.scss dist/v2/css/index.layout.css --style compressed",
+    "compile-to-css": "sass src/v2/styles/index.scss dist/v2/css/index.css --style compressed && sass src/v2/styles/index.layout.scss dist/v2/css/index.layout.css --style compressed && sass src/v2/styles/_emoji-replacement.scss dist/v2/css/emoji-replacement.css --style compressed",
     "bundle-sass": "echo '\u001b[34mℹ\u001b[0m Compiling scss files to css bundle' && sass src/v1/index.scss dist/css/index.css --style compressed && echo '\u001b[32m✓\u001b[0m Finished bundling css'",
     "copy-assets": "echo '\u001b[34mℹ\u001b[0m Copying assets to distributed directory' && cp -R src/assets dist/assets && echo '\u001b[32m✓\u001b[0m Finished copying assets'",
     "copy-styles": "echo '\u001b[34mℹ\u001b[0m Copying scss files to distributed directory' && cp -R src/v1 dist/scss && echo '\u001b[32m✓\u001b[0m Finished copying styles'",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate-docs": "ts-node scripts/generate-docs.ts",
     "replace-docs": "ts-node scripts/replacer.ts",
     "copy": "cp -R src/v2/styles/* dist/v2/scss",
-    "compile-to-css": "sass src/v2/styles/index.scss dist/v2/css/index.css --style compressed && sass src/v2/styles/index.layout.scss dist/v2/css/index.layout.css --style compressed && sass src/v2/styles/_emoji-replacement.scss dist/v2/css/emoji-replacement.css --style compressed",
+    "compile-to-css": "sass src/v2/styles/index.scss dist/v2/css/index.css --style compressed && sass src/v2/styles/index.layout.scss dist/v2/css/index.layout.css --style compressed && sass src/v2/styles/_emoji-replacement.scss dist/v2/css/emoji-replacement.css --style=compressed --no-source-map",
     "bundle-sass": "echo '\u001b[34mℹ\u001b[0m Compiling scss files to css bundle' && sass src/v1/index.scss dist/css/index.css --style compressed && echo '\u001b[32m✓\u001b[0m Finished bundling css'",
     "copy-assets": "echo '\u001b[34mℹ\u001b[0m Copying assets to distributed directory' && cp -R src/assets dist/assets && echo '\u001b[32m✓\u001b[0m Finished copying assets'",
     "copy-styles": "echo '\u001b[34mℹ\u001b[0m Copying scss files to distributed directory' && cp -R src/v1 dist/scss && echo '\u001b[32m✓\u001b[0m Finished copying styles'",

--- a/src/v1/_base.scss
+++ b/src/v1/_base.scss
@@ -105,47 +105,6 @@
   }
 }
 
-/* declare a font faces for our Emoji Replacement font, based on the default font used by Stream Chat React */
-
-$emoji-flag-unicode-range: U+1F1E6-1F1FF;
-
-/* png based woff for most browsers */
-@font-face {
-  font-family: ReplaceFlagEmojiPNG;
-  src: url('#{$assetsPath}/NotoColorEmoji-flags.woff2') format('woff2');
-  /* using the unicode-range attribute to limit the reach of the Flag Emoji web font to only flags */
-  unicode-range: $emoji-flag-unicode-range;
-}
-
-/* svg based for firefox */
-@font-face {
-  font-family: ReplaceFlagEmojiSVG;
-  src: url('#{$assetsPath}/EmojiOneColor.woff2') format('woff2');
-  unicode-range: $emoji-flag-unicode-range;
-}
-
-.str-chat--windows-flags {
-  .str-chat__textarea__textarea,
-  .str-chat__message-text-inner *,
-  .str-chat__emoji-item--entity,
-  .emoji-mart-emoji-native * {
-    font-family: ReplaceFlagEmojiPNG, var(--second-font), sans-serif;
-    font-display: swap;
-  }
-}
-
-@-moz-document url-prefix('') {
-  .str-chat--windows-flags {
-    .str-chat__textarea__textarea,
-    .str-chat__message-text-inner *,
-    .str-chat__emoji-item--entity,
-    .emoji-mart-emoji-native * {
-      font-family: ReplaceFlagEmojiSVG, var(--second-font), sans-serif;
-      font-display: swap;
-    }
-  }
-}
-
 .str-chat-channel-list {
   float: left;
 }

--- a/src/v2/styles/_emoji-replacement.scss
+++ b/src/v2/styles/_emoji-replacement.scss
@@ -17,8 +17,6 @@ $emoji-flag-unicode-range: U+1F1E6-1F1FF;
   unicode-range: $emoji-flag-unicode-range;
 }
 
-.str-chat,
-// keep str-chat--windows-flags for Angular SDK for now
 .str-chat--windows-flags {
   // TODO: consider adding the rule for reactions (list & selector) if we ever decide to make them use native emojis
   .str-chat__textarea__textarea,
@@ -31,7 +29,6 @@ $emoji-flag-unicode-range: U+1F1E6-1F1FF;
 }
 
 @-moz-document url-prefix('') {
-  .str-chat,
   .str-chat--windows-flags {
     .str-chat__textarea__textarea,
     .str-chat__message-text-inner *,

--- a/src/v2/styles/_emoji-replacement.scss
+++ b/src/v2/styles/_emoji-replacement.scss
@@ -17,7 +17,10 @@ $emoji-flag-unicode-range: U+1F1E6-1F1FF;
   unicode-range: $emoji-flag-unicode-range;
 }
 
+.str-chat,
+// keep str-chat--windows-flags for Angular SDK for now
 .str-chat--windows-flags {
+  // TODO: consider adding the rule for reactions (list & selector) if we ever decide to make them use native emojis
   .str-chat__textarea__textarea,
   .str-chat__message-text-inner *,
   .str-chat__emoji-item--entity,
@@ -28,6 +31,7 @@ $emoji-flag-unicode-range: U+1F1E6-1F1FF;
 }
 
 @-moz-document url-prefix('') {
+  .str-chat,
   .str-chat--windows-flags {
     .str-chat__textarea__textarea,
     .str-chat__message-text-inner *,

--- a/src/v2/styles/index.layout.scss
+++ b/src/v2/styles/index.layout.scss
@@ -1,5 +1,4 @@
 @use 'base';
-@use 'emoji-replacement';
 @use 'global-layout-variables';
 
 @use 'Avatar/Avatar-layout';


### PR DESCRIPTION
BREAKING CHANGE: emoji-replacement styles are now distributed separately (affects both styling versions)

### 🎯 Goal

`_emoji-replacement.scss` has been a part of the final CSS bundle even though some integrators might decide to not use this [Windows-only fallback](https://getstream.io/chat/docs/sdk/react/components/contexts/chat_context/#useimageflagemojisonwindow). Package `stream-chat-react` will be removing this flag and instead will make this set of rules optional for integrators to import explicitly if needed.