### PR TITLE
fix: prevent glitch text from overflowing elements

### DIFF
--- a/src/v2/styles/Autocomplete/Autocomplete-layout.scss
+++ b/src/v2/styles/Autocomplete/Autocomplete-layout.scss
@@ -49,6 +49,7 @@
 
   .str-chat__user-item--name {
     @include utils.ellipsis-text;
+    @include utils.prevent-glitch-text-overflow;
     width: 100%;
   }
 }

--- a/src/v2/styles/ChannelHeader/ChannelHeader-layout.scss
+++ b/src/v2/styles/ChannelHeader/ChannelHeader-layout.scss
@@ -19,5 +19,9 @@
     .str-chat__channel-header-info {
       @include utils.ellipsis-text;
     }
+
+    .str-chat__channel-header-title {
+      @include utils.prevent-glitch-text-overflow;
+    }
   }
 }

--- a/src/v2/styles/ChannelPreview/ChannelPreview-layout.scss
+++ b/src/v2/styles/ChannelPreview/ChannelPreview-layout.scss
@@ -53,6 +53,7 @@
     .str-chat__channel-preview-messenger--name,
     .str-chat__channel-preview-messenger--last-message {
       @include utils.ellipsis-text;
+      @include utils.prevent-glitch-text-overflow;
       min-width: 0;
 
       p {

--- a/src/v2/styles/ChannelSearch/ChannelSearch-layout.scss
+++ b/src/v2/styles/ChannelSearch/ChannelSearch-layout.scss
@@ -110,6 +110,11 @@
       width: 100%;
       column-gap: var(--str-chat__spacing-2);
       padding: var(--str-chat__spacing-3) var(--str-chat__spacing-2);
+
+      .channel-search__result-text,
+      .str-chat__channel-search-result--display-name {
+        @include utils.prevent-glitch-text-overflow;
+      }
     }
   }
 }

--- a/src/v2/styles/Message/Message-layout.scss
+++ b/src/v2/styles/Message/Message-layout.scss
@@ -150,6 +150,10 @@
       .str-chat__message-text {
         @include chat-bubble-spacing;
 
+        .str-chat__message-text-inner {
+          @include utils.prevent-glitch-text-overflow;
+        }
+
         p {
           white-space: pre-line;
         }
@@ -184,6 +188,10 @@
     align-items: center;
     column-gap: var(--str-chat__spacing-1);
     margin-block-start: var(--str-chat__spacing-0_5);
+
+    .str-chat__message-simple-name {
+      @include utils.prevent-glitch-text-overflow;
+    }
   }
 
   .str-chat__message-status {

--- a/src/v2/styles/Thread/Thread-layout.scss
+++ b/src/v2/styles/Thread/Thread-layout.scss
@@ -19,6 +19,10 @@
       .str-chat__thread-header-title {
         @include utils.ellipsis-text;
       }
+
+      .str-chat__thread-header-subtitle {
+        @include utils.prevent-glitch-text-overflow;
+      }
     }
 
     .str-chat__close-thread-button {

--- a/src/v2/styles/Tooltip/Tooltip-layout.scss
+++ b/src/v2/styles/Tooltip/Tooltip-layout.scss
@@ -1,6 +1,7 @@
 @use '../utils';
 
 .str-chat__tooltip {
+  @include utils.prevent-glitch-text-overflow;
   display: flex;
   padding: var(--str-chat__spacing-2);
   z-index: 1;

--- a/src/v2/styles/_utils.scss
+++ b/src/v2/styles/_utils.scss
@@ -34,6 +34,11 @@
   text-overflow: ellipsis;
 }
 
+@mixin prevent-glitch-text-overflow {
+  // Prevent glitch text from overflowing. See the generator: https://lingojam.com/GlitchTextGenerator
+  overflow-y: hidden;
+}
+
 @mixin scrollable {
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
### 🎨 UI Changes

**Before**
<img width="1128" alt="image" src="https://github.com/GetStream/stream-chat-css/assets/32706194/39f70dcc-b382-49dc-b663-c4a2ba40fc22">

<img width="257" alt="image" src="https://github.com/GetStream/stream-chat-css/assets/32706194/1faa6c8a-11bf-489a-af5d-565e0fe4259e">



**Now**
<img width="1128" alt="image" src="https://github.com/GetStream/stream-chat-css/assets/32706194/e6c2f41d-9b39-43e9-b800-10d19fd45fd0">

<img width="257" alt="image" src="https://github.com/GetStream/stream-chat-css/assets/32706194/e6fba4de-ace6-4cfe-a4ff-61204583f5d9">
