### PR TITLE
fix: file attachment preview error overlay

### DIFF
--- a/src/v2/styles/AttachmentPreviewList/AttachmentPreviewList-layout.scss
+++ b/src/v2/styles/AttachmentPreviewList/AttachmentPreviewList-layout.scss
@@ -108,6 +108,7 @@
   .str-chat__attachment-preview-error {
     @include overlay;
     @include utils.unset-button(unset);
+    inset-inline-start: 0;
     cursor: pointer;
   }
 }


### PR DESCRIPTION
### 🎯 Goal

Fix file preview error overlay position:
![Screenshot 2023-11-28 at 14 11 17](https://github.com/GetStream/stream-chat-css/assets/6690098/40575afe-6f05-4a65-9057-50028d9103d0)


### 🛠 Implementation details

_Provide a description of the implementation_

### 🎨 UI Changes

![Screenshot 2023-11-28 at 14 12 55](https://github.com/GetStream/stream-chat-css/assets/6690098/71d4b72a-20cc-4958-8cef-ce31af16dbb2)

Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
