### PR TITLE
chore: setup semantic-release for releases from v3

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,30 @@
+{
+  "branches": [
+    "main",
+    {
+      "name": "release-v3",
+      "channel": "v3",
+      "range": "3.x"
+    }
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "package.json"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github",
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": true
+      }
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -26,35 +26,6 @@
     "start": "yarn build-v1 && sass --watch src/v1/index.scss dist/css/index.css",
     "start-v2": "yarn build-v2 && yarn copy-assets && yarn copy-vendor-styles && sass --watch src/v2/styles/index.scss dist/v2/css/index.css"
   },
-  "release": {
-    "branches": [
-      "main",
-      {
-        "name": "rc",
-        "prerelease": true
-      }
-    ],
-    "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
-      [
-        "@semantic-release/npm",
-        {
-          "npmPublish": true
-        }
-      ],
-      "@semantic-release/github",
-      [
-        "@semantic-release/git",
-        {
-          "assets": [
-            "package.json"
-          ],
-          "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-        }
-      ]
-    ]
-  },
   "devDependencies": {
     "@semantic-release/git": "^10.0.1",
     "@tsconfig/recommended": "^1.0.1",


### PR DESCRIPTION
### 🎯 Goal

The separate v3 release branch is needed to avoid introducing breaking changes to stream-chat-react release-v10