### PR TITLE
feat(stream-chat-react): add styles for BaseImage to react-image-gallery stylesheet

### DIFF
--- a/src/v2/styles/vendor/react-image-gallery.scss
+++ b/src/v2/styles/vendor/react-image-gallery.scss
@@ -151,6 +151,22 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
   line-height: 0;
   top: 0;
 
+  .image-gallery-slide {
+    background-color: var(--str-chat__secondary-surface-color);
+
+    .str-chat__base-image--load-failed {
+      height: var(--str-chat__attachment-max-width);
+      width: var(--str-chat__attachment-max-width);
+      font-size: 0;
+    }
+
+    .str-chat__message-attachment-file--item-download {
+      position: absolute;
+      left: 0.375rem;
+      top: 0.375rem;
+    }
+  }
+
   &.fullscreen {
     background: $ig-black;
 


### PR DESCRIPTION
### 🎯 Goal

Related to: https://github.com/GetStream/stream-chat-react/issues/2210

The stream-chat-react SDK will use `BaseImage` component to display images and image fallbacks.

This change affects only stream-chat-react.

![image](https://github.com/GetStream/stream-chat-css/assets/32706194/adf4f28e-39d2-4d14-8c59-cfcddc3ff0c1)

