### PR TITLE
fix: position image download icon relative to the image fallback button

### DIFF
--- a/src/v2/styles/AttachmentList/AttachmentList-layout.scss
+++ b/src/v2/styles/AttachmentList/AttachmentList-layout.scss
@@ -191,6 +191,7 @@
       .str-chat__gallery-image {
         padding: 0;
         margin: 0;
+        position: relative;
 
         img {
           width: 100%;


### PR DESCRIPTION
### 🎯 Goal

Fixes: https://github.com/GetStream/stream-chat-react/issues/2209


### 🎨 UI Changes

![image](https://github.com/GetStream/stream-chat-css/assets/32706194/c57a3e34-b93d-4c89-8a61-d0f25175f77a)
