### PR TITLE
feat(angular): display all reacting users for message reactions

### DIFF
--- a/src/v2/styles/MessageReactions/MessageReactions-layout.scss
+++ b/src/v2/styles/MessageReactions/MessageReactions-layout.scss
@@ -19,6 +19,8 @@
       align-items: center;
       padding: var(--str-chat__spacing-1_5);
       position: relative;
+      cursor: pointer;
+      flex-shrink: 0;
 
       button {
         @include utils.button-reset;
@@ -51,5 +53,71 @@
 .str-chat__message--other {
   .str-chat__message-reactions-container {
     justify-content: flex-start;
+  }
+}
+
+.str-chat__message-reactions-details-modal {
+  .str-chat__modal--open {
+    .str-chat__modal__inner {
+      height: 40%;
+      max-height: 80%;
+      min-width: 90%;
+      max-width: 90%;
+      width: 90%;
+      flex-basis: min-content;
+  
+      @media only screen and (min-device-width: 768px) {
+        min-width: 40%;
+        max-width: 60%;
+        width: min-content;
+      }
+    }
+  }
+}
+
+.str-chat__message-reactions-details {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--str-chat__spacing-4);
+  max-height: 100%;
+  height: 100%;
+  min-height: 0;
+
+  .str-chat__message-reactions-details-reaction-types {
+    display: flex;
+    max-width: 100%;
+    width: 100%;
+    min-width: 0;
+    overflow-x: auto;
+    gap: var(--str-chat__spacing-4);
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+
+    .str-chat__message-reactions-details-reaction-type {
+      flex-shrink: 0;
+      cursor: pointer;
+    }
+  }
+
+  .str-chat__message-reaction-emoji-big {
+    align-self: center;
+    font-size: 2rem;
+  }
+
+  .str-chat__message-reactions-details-reacting-users {
+    display: flex;
+    flex-direction: column;
+    gap: var(--str-chat__spacing-3);
+    max-height: 100%;
+    overflow-y: auto;
+    min-height: 0;
+
+    .str-chat__message-reactions-details-reacting-user {
+      display: flex;
+      align-items: center;
+      gap: var(--str-chat__spacing-2);
+    }
   }
 }

--- a/src/v2/styles/MessageReactions/MessageReactions-theme.scss
+++ b/src/v2/styles/MessageReactions/MessageReactions-theme.scss
@@ -56,6 +56,8 @@
   --str-chat__own-message-reaction-background-color: var(
     --str-chat__primary-surface-color-low-emphasis
   );
+
+  --str-chat__messsage-reactions-details--selected-color: solid var(--str-chat__primary-color);
 }
 
 .str-chat__message-reactions-container {
@@ -71,5 +73,20 @@
         background-color: var(--str-chat__own-message-reaction-background-color);
       }
     }
+  }
+}
+
+.str-chat__message-reactions-details {
+  .str-chat__message-reactions-details-reaction-type {
+    border-block-end: solid transparent;
+  }
+
+  .str-chat__message-reactions-details-reaction-type--selected {
+    border-block-end: var(--str-chat__messsage-reactions-details--selected-color);
+  }
+
+
+  .str-chat__message-reactions-details-reacting-user {
+    font: var(--str-chat__subtitle-text);
   }
 }


### PR DESCRIPTION
### 🎯 Goal

Display all reacting users for message reactions (not just the latest 10) in Angular SDK

### 🛠 Implementation details

The tooltip was replaced with a modal window for Angular

### 🎨 UI Changes

New reactions details UI:

![Screenshot 2024-01-11 at 15 08 01](https://github.com/GetStream/stream-chat-css/assets/6690098/9829da33-4c66-4841-a94e-0611b95b0de1)
