### PR TITLE
fix: double click is required for opening reaction details

### DIFF
--- a/src/v2/styles/Message/Message-layout.scss
+++ b/src/v2/styles/Message/Message-layout.scss
@@ -261,23 +261,35 @@
 // Message options display - default mode: they appear when .str-chat__li is hovered
 .str-chat__ul:not(.str-chat__message-options-in-bubble),
 .str-chat__virtual-list:not(.str-chat__message-options-in-bubble) {
-  .str-chat__li {
-    &:hover {
-      .str-chat__message-options {
-        display: flex;
-      }
+  /* This rule won't be applied in browsers that don't support :has() */
+  .str-chat__li:hover:not(:has(.str-chat__reaction-list:hover,.str-chat__modal--open)) {
+    .str-chat__message-options {
+      display: flex;
     }
-  }
 
-  .str-chat__li:hover {
     .str-chat__message--other .str-chat__message-inner {
       margin-inline-end: 0;
     }
-  }
 
-  .str-chat__li:hover {
     .str-chat__message--me .str-chat__message-inner {
       margin-inline-start: 0;
+    }
+  }
+
+  /* Fallback for when :has() is unsupported */
+  @supports not selector(:has(a, b)) {
+    .str-chat__li:hover {
+      .str-chat__message-options {
+        display: flex;
+      }
+  
+      .str-chat__message--other .str-chat__message-inner {
+        margin-inline-end: 0;
+      }
+  
+      .str-chat__message--me .str-chat__message-inner {
+        margin-inline-start: 0;
+      }
     }
   }
 }

--- a/src/v2/styles/Message/Message-theme.scss
+++ b/src/v2/styles/Message/Message-theme.scss
@@ -308,8 +308,16 @@
   background-color: var(--str-chat__message-highlighted-background-color);
 }
 
-.str-chat__li:hover {
+/* This rule won't be applied in browsers that don't support :has() */
+.str-chat__li:hover:not(:has(.str-chat__reaction-list:hover,.str-chat__modal--open)) {
   background-color: var(--str-chat__message-active-bacground-color);
+}
+
+/* Fallback for when :has() is unsupported */
+@supports not selector(:has(a, b)) {
+  .str-chat__li:hover {
+    background-color: var(--str-chat__message-active-bacground-color);
+  }
 }
 
 .str-chat__li--top,


### PR DESCRIPTION
### 🎯 Goal

With the new Angular reaction details UI it took two clicks on mobile to open the reactions (first was to open message options, second to open the modal). To fix that clicking on a reaction icon won't open the message options.

### 🛠 Implementation details

It uses the new `:has` selector which doesn't yet have [complete browser support](https://caniuse.com/?search=%3Ahas) so we use the [`@supports` syntax ](https://caniuse.com/?search=%40supports) to only use the selector in browsers that support it. For other browsers the users will have to click twice to open the message reactions.

⚠️ Autoprefixer might need to be updated in older applications that use the React/Angular SDK: https://getstream.slack.com/archives/C06CF5TKRGA/p1704989315231429

### 🎨 UI Changes

The message options not displayed when hovering over a reaction icon:

React sample app screenshots:

Before:
<img width="411" alt="Screenshot 2024-01-12 at 10 04 18" src="https://github.com/GetStream/stream-chat-css/assets/6690098/5caf7536-799a-4356-af20-826c10e70db1">

After:

<img width="374" alt="Screenshot 2024-01-12 at 10 24 35" src="https://github.com/GetStream/stream-chat-css/assets/6690098/a6d1df2a-6254-4be4-a230-7160a2c65977">
