### PR TITLE
fix: use popper to properly position message actions box

### DIFF
--- a/src/v2/styles/Message/Message-layout.scss
+++ b/src/v2/styles/Message/Message-layout.scss
@@ -262,7 +262,7 @@
 .str-chat__ul:not(.str-chat__message-options-in-bubble),
 .str-chat__virtual-list:not(.str-chat__message-options-in-bubble) {
   /* This rule won't be applied in browsers that don't support :has() */
-  .str-chat__li:hover:not(:has(.str-chat__reaction-list:hover,.str-chat__modal--open)) {
+  .str-chat__li:hover:not(:has(.str-chat__reaction-list:hover, .str-chat__modal--open)) {
     .str-chat__message-options {
       display: flex;
     }
@@ -282,11 +282,11 @@
       .str-chat__message-options {
         display: flex;
       }
-  
+
       .str-chat__message--other .str-chat__message-inner {
         margin-inline-end: 0;
       }
-  
+
       .str-chat__message--me .str-chat__message-inner {
         margin-inline-start: 0;
       }
@@ -442,15 +442,15 @@
     white-space: nowrap;
   }
 
-    button:first-of-type {
-      padding-inline: 0.75rem 0.375rem;
-    }
+  button:first-of-type {
+    padding-inline: 0.75rem 0.375rem;
+  }
 
-    button:last-of-type {
-      padding-inline: 0.375rem 0.75rem;
+  button:last-of-type {
+    padding-inline: 0.375rem 0.75rem;
 
-      svg {
-        width: 0.875rem;
-      }
+    svg {
+      width: 0.875rem;
     }
+  }
 }

--- a/src/v2/styles/MessageActionsBox/MessageActionsBox-layout.scss
+++ b/src/v2/styles/MessageActionsBox/MessageActionsBox-layout.scss
@@ -21,21 +21,10 @@
 
 .str-chat__message-actions-box:not(.str-chat__message-actions-box-angular) {
   display: none;
-  position: absolute;
   z-index: 1;
 
   &.str-chat__message-actions-box--open {
     display: block;
-  }
-
-  &.str-chat__message-actions-box--mine {
-    inset-block-end: 100%;
-    inset-inline-start: 100%;
-  }
-
-  &:not(.str-chat__message-actions-box--mine) {
-    inset-block-end: 100%;
-    inset-inline-end: 100%;
   }
 }
 


### PR DESCRIPTION
### 🎯 Goal

See detailed description here: https://github.com/GetStream/stream-chat-react/pull/2241

### 🛠 Implementation details

This PR only deals with v2 themes, but v1 theme updates should also probably be added.
