### PR TITLE
feat: update styles for reactions modal

### DIFF
--- a/src/v2/styles/MessageReactions/MessageReactions-layout.scss
+++ b/src/v2/styles/MessageReactions/MessageReactions-layout.scss
@@ -65,7 +65,7 @@
       max-width: 90%;
       width: 90%;
       flex-basis: min-content;
-  
+
       @media only screen and (min-device-width: 768px) {
         min-width: 40%;
         max-width: 60%;
@@ -96,6 +96,9 @@
     flex-shrink: 0;
 
     .str-chat__message-reactions-details-reaction-type {
+      display: flex;
+      align-items: center;
+      padding: var(--str-chat__spacing-1) 0;
       flex-shrink: 0;
       cursor: pointer;
     }


### PR DESCRIPTION
### 🎯 Goal

We're updating UI for displaying reactions. Instead of showing the latest reactions only, we're adding a separate modal window full the full list of reactions.

### 🛠 Implementation details

React SDK renders emoji as block elements, so some additional styling was required. BTW, that means that [inline styling](https://github.com/GetStream/stream-chat-angular/blob/1ab3e26a3d89df85d6973c420529d52873186923/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts#L27) can be removed in Angular SDK (cc @szuperaz).