### PR TITLE
fix: reaction list is now scrollable

### DIFF
--- a/src/v2/styles/MessageReactions/MessageReactions-layout.scss
+++ b/src/v2/styles/MessageReactions/MessageReactions-layout.scss
@@ -4,6 +4,9 @@
   display: flex;
 
   .str-chat__message-reactions {
+    overflow-y: hidden;
+    overflow-x: auto;
+    scrollbar-width: none;
     list-style: none;
     display: flex;
     margin-block-start: var(--str-chat__spacing-0_5);


### PR DESCRIPTION
### 🎯 Goal

This PR affects both Angular and React

This is an old bug, but we probably didn't notice it because it requires lots of reactions + very narrow device: but the reaction list above the message bubble could overflow. 

### 🛠 Implementation details

This PR adds scrolling to the reaction list

A room for improvement: the reaction list could fill the whole width of the message list (see screenshots for visual explanation), this is currently not happening due to our CSS/HTML structure. Since this is not an easy fix, I'll leave this to our future selves.

### 🎨 UI Changes

Before:
![Screenshot 2024-01-31 at 16 20 06](https://github.com/GetStream/stream-chat-css/assets/6690098/264d693b-a6fc-401b-9e32-29d346b2f1d3)

After:
![Screenshot 2024-01-31 at 16 24 00](https://github.com/GetStream/stream-chat-css/assets/6690098/5974ab99-6061-4dd1-9a26-04d5f1209c66)



Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
