### PR TITLE
feat: rename MessageBounceOptions ➡️ MessageBouncePrompt

### DIFF
--- a/src/v2/styles/MessageBouncePrompt/MessageBouncePrompt-layout.scss
+++ b/src/v2/styles/MessageBouncePrompt/MessageBouncePrompt-layout.scss
@@ -1,4 +1,4 @@
-.str-chat__message-bounce-options {
+.str-chat__message-bounce-prompt {
   display: flex;
   flex-direction: column;
   gap: var(--str-chat__spacing-9);

--- a/src/v2/styles/MessageBouncePrompt/MessageBouncePrompt-layout.scss
+++ b/src/v2/styles/MessageBouncePrompt/MessageBouncePrompt-layout.scss
@@ -1,6 +1,7 @@
 .str-chat__message-bounce-prompt {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: var(--str-chat__spacing-9);
 
   .str-chat__message-bounce-actions {
@@ -14,5 +15,11 @@
   .str-chat__message-bounce-delete {
     cursor: pointer;
     padding: var(--str-chat__spacing-2);
+  }
+
+  .str-chat__quoted-message-preview {
+    .str-chat__quoted-message-bubble {
+      --str-chat__message-max-width: calc(var(--str-chat__spacing-px) * 480);
+    }
   }
 }

--- a/src/v2/styles/MessageBouncePrompt/MessageBouncePrompt-layout.scss
+++ b/src/v2/styles/MessageBouncePrompt/MessageBouncePrompt-layout.scss
@@ -16,10 +16,4 @@
     cursor: pointer;
     padding: var(--str-chat__spacing-2);
   }
-
-  .str-chat__quoted-message-preview {
-    .str-chat__quoted-message-bubble {
-      --str-chat__message-max-width: calc(var(--str-chat__spacing-px) * 480);
-    }
-  }
 }

--- a/src/v2/styles/MessageBouncePrompt/MessageBouncePrompt-theme.scss
+++ b/src/v2/styles/MessageBouncePrompt/MessageBouncePrompt-theme.scss
@@ -29,7 +29,7 @@
   --str-chat__message-bounce-button-box-shadow: none;
 }
 
-.str-chat__message-bounce-options {
+.str-chat__message-bounce-prompt {
   .str-chat__message-bounce-edit,
   .str-chat__message-bounce-send,
   .str-chat__message-bounce-delete {
@@ -47,5 +47,11 @@
 
   .str-chat__message-bounce-delete {
     color: var(--str-chat__message-bounce-delete-button-color);
+  }
+
+  .str-chat__quoted-message-preview {
+    .str-chat__quoted-message-bubble {
+      background-color: var(--str-chat__message-bubble-background-color);
+    }
   }
 }

--- a/src/v2/styles/MessageBouncePrompt/MessageBouncePrompt-theme.scss
+++ b/src/v2/styles/MessageBouncePrompt/MessageBouncePrompt-theme.scss
@@ -48,10 +48,4 @@
   .str-chat__message-bounce-delete {
     color: var(--str-chat__message-bounce-delete-button-color);
   }
-
-  .str-chat__quoted-message-preview {
-    .str-chat__quoted-message-bubble {
-      background-color: var(--str-chat__message-bubble-background-color);
-    }
-  }
 }

--- a/src/v2/styles/index.layout.scss
+++ b/src/v2/styles/index.layout.scss
@@ -20,7 +20,7 @@
 @use 'LoadingIndicator/LoadingIndicator-layout';
 @use 'Message/Message-layout';
 @use 'MessageActionsBox/MessageActionsBox-layout';
-@use 'MessageBounceOptions/MessageBounceOptions-layout';
+@use 'MessageBouncePrompt/MessageBouncePrompt-layout';
 @use 'MessageInput/MessageInput-layout';
 @use 'MessageList/MessageList-layout';
 @use 'MessageList/VirtualizedMessageList-layout';

--- a/src/v2/styles/index.scss
+++ b/src/v2/styles/index.scss
@@ -22,7 +22,7 @@
 @use 'LoadingIndicator/LoadingIndicator-theme';
 @use 'Message/Message-theme';
 @use 'MessageActionsBox/MessageActionsBox-theme';
-@use 'MessageBounceOptions/MessageBounceOptions-theme';
+@use 'MessageBouncePrompt/MessageBouncePrompt-theme';
 @use 'MessageInput/MessageInput-theme';
 @use 'MessageList/MessageList-theme';
 @use 'MessageList/VirtualizedMessageList-theme';


### PR DESCRIPTION
🚂 #264 

We've picked a better name for ~`MessageBounceOptions`~ `MessageBouncePrompt`, but that means we have to rename our css classes as well.

The feature has not been released yet, so not a breaking change :)