### PR TITLE
fix: make message actions keyboard accessible

### DIFF
--- a/src/v2/styles/Message/Message-layout.scss
+++ b/src/v2/styles/Message/Message-layout.scss
@@ -269,7 +269,8 @@
 .str-chat__ul:not(.str-chat__message-options-in-bubble),
 .str-chat__virtual-list:not(.str-chat__message-options-in-bubble) {
   /* This rule won't be applied in browsers that don't support :has() */
-  .str-chat__li:hover:not(:has(.str-chat__reaction-list:hover, .str-chat__modal--open)) {
+  .str-chat__li:hover:not(:has(.str-chat__reaction-list:hover, .str-chat__modal--open)),
+  .str-chat__li:focus-within:not(:has(.str-chat__reaction-list:focus-within, .str-chat__modal--open)) {
     .str-chat__message-options {
       display: flex;
     }
@@ -285,7 +286,8 @@
 
   /* Fallback for when :has() is unsupported */
   @supports not selector(:has(a, b)) {
-    .str-chat__li:hover {
+    .str-chat__li:hover,
+    .str-chat__li:focus-within {
       .str-chat__message-options {
         display: flex;
       }

--- a/src/v2/styles/_utils.scss
+++ b/src/v2/styles/_utils.scss
@@ -63,7 +63,6 @@
 }
 
 @mixin button-reset {
-  outline: none;
   background: none;
   border: none;
 }


### PR DESCRIPTION
### 🎯 Goal

Currently message actions are only displayed on hover, and are not accessible from keyboard. This PR makes message actions more accessible.

### 🛠 Implementation details

1. Message actions are now displayed when the message is focused
2. Action buttons now have outline to clearly show focus

This PR includes a slightly scary change to the `button-reset` mixin. Previously it removed outline. However, having outline for focused items is important for accessibility, so now outline is not removed.

### 🎨 UI Changes

https://github.com/GetStream/stream-chat-css/assets/975978/7824625d-5ba0-4ba1-b4b5-1572194e33ac

