### PR TITLE
fix(angular): make images bigger in image modal

### DIFF
--- a/src/v2/styles/ImageCarousel/ImageCarousel-layout.scss
+++ b/src/v2/styles/ImageCarousel/ImageCarousel-layout.scss
@@ -1,11 +1,13 @@
 .str-chat__image-carousel {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  justify-content: space-between;
   align-items: center;
   min-height: 0;
   min-width: 0;
   max-width: 100%;
   max-height: 100%;
+  height: 100%;
 
   .str-chat__image-carousel-stepper {
     padding: var(--str-chat__spacing-2_5);
@@ -15,11 +17,13 @@
   }
 
   .str-chat__image-carousel-image {
-    object-fit: cover;
+    object-fit: contain;
     min-height: 0;
     max-height: 100%;
     min-width: 0;
     max-width: 100%;
+    height: 100%;
+    width: 100%;
   }
 }
 
@@ -29,6 +33,11 @@
       .str-chat__modal__inner {
         height: 80%;
         width: 80%;
+
+        @media only screen and (max-device-width: 768px) {
+          height: 100%;
+          width: 100%;
+        }
       }
     }
   }

--- a/src/v2/styles/ImageCarousel/ImageCarousel-theme.scss
+++ b/src/v2/styles/ImageCarousel/ImageCarousel-theme.scss
@@ -6,8 +6,21 @@
   --str-chat__image-carousel-stepper-color: var(--str-chat__text-color);
 }
 
+@media only screen and (max-device-width: 768px) {
+  .str-chat__message {
+    .str-chat__attachment-list {
+      .str-chat__modal--open {
+        .str-chat__modal__inner {
+          border-radius: 0;
+        }
+      }
+    }
+  }
+}
+
 .str-chat__image-carousel {
   .str-chat__image-carousel-stepper {
+    cursor: pointer;
     svg path {
       fill: var(--str-chat__image-carousel-stepper-color);
     }


### PR DESCRIPTION
### 🎯 Goal

This is an Angular-only change, React uses a different UI for image modals.

### 🛠 Implementation details

On the Angular SDK the images in the attachment modal were quite small. There were two reasons for this:
- The layout was built in a way that didn't maximize space for images
- We didn't have a responsive layout to make the modal bigger on mobile devices -> we generally don't provide different layouts on different devices, but I think this is one of the few places where it makes sense to add a media rule

### 🎨 UI Changes

Before:
![IMG_3350](https://github.com/GetStream/stream-chat-css/assets/6690098/b15b310c-1c43-41b4-9adf-e4d23f904b5a)

After:
![IMG_3349](https://github.com/GetStream/stream-chat-css/assets/6690098/b1aafa00-1aef-4dce-b31e-c696f27d20d0)

Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
