### PR TITLE
fix: syntax for $min_amplitude_height

### DIFF
--- a/src/v2/styles/AttachmentList/AttachmentList-layout.scss
+++ b/src/v2/styles/AttachmentList/AttachmentList-layout.scss
@@ -388,13 +388,15 @@
       .str-chat__wave-progress-bar__amplitude-bar {
         width: 2px;
         min-width: 2px;
-        height: calc(var(--str-chat__wave-progress-bar__amplitude-bar-height) + $min_amplitude_height); // variable set dynamically on element
+        height: calc(
+          var(--str-chat__wave-progress-bar__amplitude-bar-height) + #{$min_amplitude_height}
+        ); // variable set dynamically on element
       }
 
       .str-chat__wave-progress-bar__progress-indicator {
         position: absolute;
         left: 0;
-        height: calc(100% + $min_amplitude_height + 2px);
+        height: calc(100% + #{$min_amplitude_height} + 2px);
         width: calc(var(--str-chat__spacing-px) * 6);
       }
     }


### PR DESCRIPTION
### 🎯 Goal

I think we only need this for older SCSS versions (like the one used in Angular 12 apps)

### 🛠 Implementation details

`$min_amplitude_height` is wrapped with `#{}` when used in `calc` expressions
### 🎨 UI Changes

_Add relevant screenshots_

Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
