### PR TITLE
feat: add error message and download icon to voice recordings

### DIFF
--- a/src/v2/styles/AttachmentList/AttachmentList-layout.scss
+++ b/src/v2/styles/AttachmentList/AttachmentList-layout.scss
@@ -363,12 +363,39 @@
       flex-direction: column;
       gap: var(--str-chat__spacing-2);
 
+      a {
+        cursor: pointer;
+        text-decoration: none;
+      }
+
+      .str-chat__message-attachment-voice-recording-widget--first-row {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        column-gap: var(--str-chat__spacing-1);
+      }
+
+      .str-chat__message-attachment-download-icon {
+        svg {
+          width: calc(var(--str-chat__spacing-px) * 24);
+          height: calc(var(--str-chat__spacing-px) * 16);
+        }
+      }
+
       .str-chat__message-attachment__voice-recording-widget__audio-state {
         display: flex;
         align-items: center;
         justify-content: space-between;
         gap: var(--str-chat__spacing-1_5);
         height: 100%;
+      }
+
+      .str-chat__message-attachment__voice-recording-widget__error-message {
+        display: flex;
+        align-items: center;
+        justify-content: start;
+        gap: var(--str-chat__spacing-1);
       }
     }
 
@@ -476,7 +503,8 @@
   }
 
   /* Angular has different UI here, the download icon is too small to use on mobile */
-  .str-chat-angular__message-attachment-file-single {
+  .str-chat-angular__message-attachment-file-single
+    .str-chat__message-attachment-file--item-first-row {
     cursor: pointer;
     text-decoration: none;
   }

--- a/src/v2/styles/AttachmentList/AttachmentList-theme.scss
+++ b/src/v2/styles/AttachmentList/AttachmentList-theme.scss
@@ -179,10 +179,14 @@
   --str-chat__voice-recording-attachment-widget-color: var(--str-chat__text-color);
 
   /* Border radius applied to audio recording widget */
-  --str-chat__voice-recording-attachment-widget-secondary-color: var(--str-chat__text-low-emphasis-color);
+  --str-chat__voice-recording-attachment-widget-secondary-color: var(
+    --str-chat__text-low-emphasis-color
+  );
 
   /* The text/icon color for low emphasis texts (for example file size) in audio recording widget */
-  --str-chat__voice-recording-attachment-widget-background-color: var(--str-chat__secondary-background-color);
+  --str-chat__voice-recording-attachment-widget-background-color: var(
+    --str-chat__secondary-background-color
+  );
 
   /* Top border of audio recording widget */
   --str-chat__voice-recording-attachment-widget-border-block-start: none;
@@ -346,7 +350,7 @@
   .str-chat__message-attachment-audio-widget--progress-track {
     background: linear-gradient(
       to right,
-      var(--str-chat__primary-color)  var(--str-chat__message-attachment-audio-widget-progress),
+      var(--str-chat__primary-color) var(--str-chat__message-attachment-audio-widget-progress),
       var(--str-chat__disabled-color) var(--str-chat__message-attachment-audio-widget-progress)
     );
     border-radius: calc(var(--str-chat__spacing-px) * 5);
@@ -364,6 +368,10 @@
 
   .str-chat__message-attachment__voice-recording-widget {
     @include utils.component-layer-overrides('voice-recording-attachment-widget');
+
+    a {
+      color: var(--str-chat__voice-recording-attachment-widget-color);
+    }
 
     .str-chat__message-attachment__voice-recording-widget__title {
       @include utils.ellipsis-text;
@@ -390,6 +398,11 @@
       border-radius: var(--str-chat__border-radius-circle);
       border: 1px solid var(--str-chat__secondary-overlay-color);
       cursor: grab;
+    }
+
+    .str-chat__message-attachment__voice-recording-widget__error-message {
+      font: var(--str-chat__body-text);
+      color: var(--str-chat__text-low-emphasis-color);
     }
   }
 
@@ -468,4 +481,9 @@
     border-end-start-radius: 0;
     border-end-end-radius: 0;
   }
+}
+
+.str-chat-angular__message-attachment-file-single
+  .str-chat__message-attachment-file--item-first-row {
+  color: var(--str-chat__attachment-list-color);
 }


### PR DESCRIPTION
### 🎯 Goal

- Add error message to voice recording
- Add download icon to voice recording -> Angular will be released without downloading (there are some issues downloading memos from Android and RN) but I pushed the markup if the issues are fixed, we can just easily turn this on
- Adjust angular template for file attachments -> previously clicking anywhere in the attachment markup downloaded the file, now only clicking on the file name or download icon will cause download

### 🛠 Implementation details

This is currently Angular-only, React can follow with implementation

### 🎨 UI Changes

Markup with error message + download icon
![Screenshot 2024-03-25 at 13 08 06](https://github.com/GetStream/stream-chat-css/assets/6690098/8e95b4a4-86f8-43fb-ad61-0180b6ba1fcf)

Since we have some problems with downloads, the released markup in the Angular SDK won't feature a link to download the voice memo:

![Screenshot 2024-03-25 at 13 21 41](https://github.com/GetStream/stream-chat-css/assets/6690098/97aadefa-b78f-4450-9776-23022422edef)

Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
