### PR TITLE
fix: some letter are cut-off

### DIFF
--- a/src/v2/styles/_global-theme-variables.scss
+++ b/src/v2/styles/_global-theme-variables.scss
@@ -19,43 +19,43 @@
     Cantarell, Helvetica Neue, sans-serif;
 
   /* The font used for caption texts */
-  --str-chat__caption-text: 0.75rem/1rem var(--str-chat__font-family);
+  --str-chat__caption-text: 0.75rem/1.3 var(--str-chat__font-family);
 
   /* The font used for caption texts with emphasize */
-  --str-chat__caption-medium-text: 500 0.75rem/1rem var(--str-chat__font-family);
+  --str-chat__caption-medium-text: 500 0.75rem/1.3 var(--str-chat__font-family);
 
   /* The font used for caption texts with emphasize */
-  --str-chat__caption-strong-text: 700 0.75rem/1rem var(--str-chat__font-family);
+  --str-chat__caption-strong-text: 700 0.75rem/1.3 var(--str-chat__font-family);
 
   /* The font used for body texts */
-  --str-chat__body-text: 0.875rem/1rem var(--str-chat__font-family);
+  --str-chat__body-text: 0.875rem/1.2 var(--str-chat__font-family);
 
   /* The font used for body texts with emphasize */
-  --str-chat__body-medium-text: 500 0.875rem/1rem var(--str-chat__font-family);
+  --str-chat__body-medium-text: 500 0.875rem/1.2 var(--str-chat__font-family);
 
   /* The font used for body texts */
-  --str-chat__body2-text: 0.9375rem/1rem var(--str-chat__font-family);
+  --str-chat__body2-text: 0.9375rem/1.2 var(--str-chat__font-family);
 
   /* The font used for body texts with emphasize */
-  --str-chat__body2-medium-text: 500 0.9375rem/1rem var(--str-chat__font-family);
+  --str-chat__body2-medium-text: 500 0.9375rem/1.2 var(--str-chat__font-family);
 
   /* The font used for subtitle texts */
-  --str-chat__subtitle-text: 1rem/1.25rem var(--str-chat__font-family);
+  --str-chat__subtitle-text: 1rem/1.1.25 var(--str-chat__font-family);
 
   /* The font used for subtitle texts with emphasize */
-  --str-chat__subtitle-medium-text: 500 1rem/1.25rem var(--str-chat__font-family);
+  --str-chat__subtitle-medium-text: 500 1rem/1.25 var(--str-chat__font-family);
 
   /* The font used for subtitle texts */
-  --str-chat__subtitle2-text: 1.25rem/1.5rem var(--str-chat__font-family);
+  --str-chat__subtitle2-text: 1.25rem/1.2 var(--str-chat__font-family);
 
   /* The font used for subtitle texts with emphasize */
-  --str-chat__subtitle2-medium-text: 500 1.25rem/1.5rem var(--str-chat__font-family);
+  --str-chat__subtitle2-medium-text: 500 1.25rem/1.2 var(--str-chat__font-family);
 
   /* The font used for headline texts */
-  --str-chat__headline-text: 1.5rem/1.5rem var(--str-chat__font-family);
+  --str-chat__headline-text: 1.5rem/1.2 var(--str-chat__font-family);
 
   /* The font used for headline texts */
-  --str-chat__headline2-text: 1.8rem/1.8rem var(--str-chat__font-family);
+  --str-chat__headline2-text: 1.8rem/1.2 var(--str-chat__font-family);
 }
 
 .str-chat,


### PR DESCRIPTION
### 🎯 Goal

Some letter are cut-off

![Screenshot 2024-04-03 at 17 03 25](https://github.com/GetStream/stream-chat-css/assets/6690098/a45fd7e4-3137-4135-9a33-0a2cd3acc70c)

### 🛠 Implementation details
- I've updated all `line-height` values to be unitless
- I made sure we use at least `1.2` everywhere

Context: https://getstream.slack.com/archives/C06CF5TKRGA/p1712156840771619

### 🎨 UI Changes

![Screenshot 2024-04-04 at 11 04 21 (1)](https://github.com/GetStream/stream-chat-css/assets/6690098/39d214a0-fc51-4898-8b68-e0d816db6d96)

Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
