### PR TITLE
fix: use flex-start instead of start

### DIFF
--- a/src/v2/styles/AttachmentList/AttachmentList-layout.scss
+++ b/src/v2/styles/AttachmentList/AttachmentList-layout.scss
@@ -401,7 +401,7 @@
       .str-chat__message-attachment__voice-recording-widget__error-message {
         display: flex;
         align-items: center;
-        justify-content: start;
+        justify-content: flex-start;
         gap: var(--str-chat__spacing-1);
       }
     }

--- a/src/v2/styles/Message/Message-layout.scss
+++ b/src/v2/styles/Message/Message-layout.scss
@@ -76,7 +76,7 @@
       '. metadata';
     column-gap: var(--str-chat__spacing-2);
     grid-template-columns: auto 1fr;
-    justify-items: start;
+    justify-items: flex-start;
   }
 
   &.str-chat__message--me {
@@ -120,7 +120,7 @@
 
     .str-chat__message-options {
       grid-area: options;
-      align-items: start;
+      align-items: flex-start;
       justify-content: flex-end;
       flex-direction: row-reverse;
       width: calc(3 * var(--str-chat__message-options-button-size));


### PR DESCRIPTION
### 🎯 Goal

We use `flex-start` in the CSS codebase, these two were just a mistake I guess, but they're causing warning from autoprefixer ("autoprefixer: start value has mixed support, consider using flex-start instead")

### 🛠 Implementation details

_Provide a description of the implementation_

### 🎨 UI Changes

_Add relevant screenshots_

Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
