### PR TITLE
fix: remove unnecessary selector specificity from font-family setting

### DIFF
--- a/src/v2/styles/_base.scss
+++ b/src/v2/styles/_base.scss
@@ -1,13 +1,14 @@
 .str-chat {
   box-sizing: border-box;
+  font-family: var(--str-chat__font-family);
 
   * {
-    font-family: var(--str-chat__font-family);
     box-sizing: border-box;
   }
 
   // Overriding styles of ngx-popperjs/ngx-float-ui
-  .ngxp__container, .float-ui-container {
+  .ngxp__container,
+  .float-ui-container {
     z-index: 1;
     padding: 0 !important;
     box-shadow: none !important;


### PR DESCRIPTION
### 🎯 Goal

Fix this issue: https://github.com/GetStream/stream-chat-angular/issues/603

### 🛠 Implementation details

The `font-family` setting is inherited, so there is no need for the extra ` *` selector, which can make integrators' lives harder.

### 🎨 UI Changes

_Add relevant screenshots_

Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
