### PR TITLE
feat: add styles for unsupported message attachment

### DIFF
--- a/src/v2/styles/AttachmentList/AttachmentList-layout.scss
+++ b/src/v2/styles/AttachmentList/AttachmentList-layout.scss
@@ -253,6 +253,31 @@
     }
   }
 
+  .str-chat__message-attachment-unsupported {
+    @include utils.flex-row-center;
+    padding: var(--str-chat__spacing-2);
+    column-gap: var(--str-chat__spacing-4);
+    margin: var(--str-chat__attachment-margin);
+
+    .str-chat__file-icon {
+      width: calc(var(--str-chat__spacing-px)* 30);
+    }
+
+    .str-chat__message-attachment-unsupported__metadata {
+      min-width: 0;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: center;
+
+    }
+    .str-chat__message-attachment-unsupported__title {
+      @include utils.ellipsis-text;
+      max-width: 100%;
+    }
+  }
+
   .str-chat__message-attachment-file--item,
   .str-chat__message-attachment-audio-widget {
     @include utils.flex-row-center;

--- a/src/v2/styles/AttachmentList/AttachmentList-layout.scss
+++ b/src/v2/styles/AttachmentList/AttachmentList-layout.scss
@@ -272,6 +272,7 @@
       justify-content: center;
 
     }
+
     .str-chat__message-attachment-unsupported__title {
       @include utils.ellipsis-text;
       max-width: 100%;

--- a/src/v2/styles/AttachmentList/AttachmentList-theme.scss
+++ b/src/v2/styles/AttachmentList/AttachmentList-theme.scss
@@ -331,6 +331,7 @@
       word-break: keep-all;
     }
   }
+
   .str-chat__message-attachment-file--item,
   .str-chat__message-attachment-audio-widget {
     .str-chat__message-attachment-file--item-name,

--- a/src/v2/styles/AttachmentList/AttachmentList-theme.scss
+++ b/src/v2/styles/AttachmentList/AttachmentList-theme.scss
@@ -320,10 +320,17 @@
     background-size: 24px 24px;
   }
 
+  .str-chat__message-attachment-unsupported,
   .str-chat__message-attachment-file--item {
     @include utils.component-layer-overrides('file-attachment');
   }
 
+  .str-chat__message-attachment-unsupported {
+    .str-chat__message-attachment-unsupported__title {
+      font: var(--str-chat__subtitle-medium-text);
+      word-break: keep-all;
+    }
+  }
   .str-chat__message-attachment-file--item,
   .str-chat__message-attachment-audio-widget {
     .str-chat__message-attachment-file--item-name,

--- a/src/v2/styles/AttachmentPreviewList/AttachmentPreviewList-layout.scss
+++ b/src/v2/styles/AttachmentPreviewList/AttachmentPreviewList-layout.scss
@@ -47,6 +47,7 @@
     }
   }
 
+  .str-chat__attachment-preview-unknown,
   .str-chat__attachment-preview-voice-recording,
   .str-chat__attachment-preview-file {
     display: flex;
@@ -68,6 +69,7 @@
       align-items: flex-start;
       justify-content: center;
 
+      .str-chat__attachment-preview-title,
       .str-chat__attachment-preview-file-name {
         @include utils.ellipsis-text;
         max-width: 100%;

--- a/src/v2/styles/AttachmentPreviewList/AttachmentPreviewList-layout.scss
+++ b/src/v2/styles/AttachmentPreviewList/AttachmentPreviewList-layout.scss
@@ -47,7 +47,7 @@
     }
   }
 
-  .str-chat__attachment-preview-unknown,
+  .str-chat__attachment-preview-unsupported,
   .str-chat__attachment-preview-voice-recording,
   .str-chat__attachment-preview-file {
     display: flex;

--- a/src/v2/styles/AttachmentPreviewList/AttachmentPreviewList-theme.scss
+++ b/src/v2/styles/AttachmentPreviewList/AttachmentPreviewList-theme.scss
@@ -107,10 +107,12 @@
     }
   }
 
+  .str-chat__attachment-preview-unknown,
   .str-chat__attachment-preview-voice-recording,
   .str-chat__attachment-preview-file {
     @include utils.component-layer-overrides('attachment-preview-file');
 
+    .str-chat__attachment-preview-title,
     .str-chat__attachment-preview-file-name {
       font: var(--str-chat__subtitle-medium-text);
     }

--- a/src/v2/styles/AttachmentPreviewList/AttachmentPreviewList-theme.scss
+++ b/src/v2/styles/AttachmentPreviewList/AttachmentPreviewList-theme.scss
@@ -107,7 +107,7 @@
     }
   }
 
-  .str-chat__attachment-preview-unknown,
+  .str-chat__attachment-preview-unsupported,
   .str-chat__attachment-preview-voice-recording,
   .str-chat__attachment-preview-file {
     @include utils.component-layer-overrides('attachment-preview-file');


### PR DESCRIPTION
### 🎯 Goal

Add styles for unsupported message attachment

Related to https://github.com/GetStream/stream-chat-react/pull/2383

Unknown attachments are by default rendered as follows:

1. Message attachment in a message list:

![image](https://github.com/GetStream/stream-chat-react/assets/32706194/b2fd9093-c884-4bfa-ace7-4e56abd95044)

2. Message attachment preview in message composer

<img width="808" alt="image" src="https://github.com/GetStream/stream-chat-react/assets/32706194/586d93a1-9905-4310-8574-f3deaa875a49">