### PR TITLE
fix: allow configuring asset path for icons

### DIFF
--- a/src/v2/styles/_emoji-replacement.scss
+++ b/src/v2/styles/_emoji-replacement.scss
@@ -1,5 +1,7 @@
-/* declare a font faces for our Emoji Replacement font, based on the default font used by Stream Chat React */
-$assetsPath: '../../assets' !default;
+@use 'variables';
+
+$assetsPath: variables.$assetsPath !default;
+
 $emoji-flag-unicode-range: U+1F1E6-1F1FF;
 
 /* png based woff for most browsers */

--- a/src/v2/styles/_icons.scss
+++ b/src/v2/styles/_icons.scss
@@ -1,15 +1,17 @@
+@use 'variables';
+
 .str-chat {
   --str-chat__image-fallback-icon: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9ImN1cnJlbnRDb2xvciIgY2xhc3M9InN0ci1jaGF0X19pbWFnZS1mYWxsYmFja19faWNvbiIgdmlld0JveD0iMCAwIDE4IDE4Ij48cGF0aCBkPSJNMTYgMnYxNEgyVjJoMTRabTAtMkgyQy45IDAgMCAuOSAwIDJ2MTRjMCAxLjEuOSAyIDIgMmgxNGMxLjEgMCAyLS45IDItMlYyYzAtMS4xLS45LTItMi0yWm0tNC44NiA4Ljg2LTMgMy44N0w2IDEwLjE0IDMgMTRoMTJsLTMuODYtNS4xNFoiLz48L3N2Zz4=');
 }
 
 @font-face {
   font-family: 'stream-chat-icons';
-  src: url('../assets/icons/stream-chat-icons.eot');
-  src: url('../assets/icons/stream-chat-icons.eot#iefix') format('embedded-opentype'),
-    url('../assets/icons/stream-chat-icons.woff') format('woff2'),
-    url('../assets/icons/stream-chat-icons.woff') format('woff'),
-    url('../assets/icons/stream-chat-icons.ttf') format('truetype'),
-    url('../assets/icons/stream-chat-icons.svg#stream-chat-icons') format('svg');
+  src: url('#{variables.$assetsPath}/icons/stream-chat-icons.eot');
+  src: url('#{variables.$assetsPath}/icons/stream-chat-icons.eot#iefix') format('embedded-opentype'),
+    url('#{variables.$assetsPath}/icons/stream-chat-icons.woff') format('woff2'),
+    url('#{variables.$assetsPath}/icons/stream-chat-icons.woff') format('woff'),
+    url('#{variables.$assetsPath}/icons/stream-chat-icons.ttf') format('truetype'),
+    url('#{variables.$assetsPath}/icons/stream-chat-icons.svg#stream-chat-icons') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -18,6 +20,6 @@
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
   @font-face {
     font-family: 'stream-chat-icons';
-    src: url('../assets/icons/stream-chat-icons.svg#stream-chat-icons') format('svg');
+    src: url('#{variables.$assetsPath}/icons/stream-chat-icons.svg#stream-chat-icons') format('svg');
   }
 }

--- a/src/v2/styles/_variables.scss
+++ b/src/v2/styles/_variables.scss
@@ -1,0 +1,2 @@
+/* declare asset path, useful if you want to create your own style bundle */
+$assetsPath: '../../assets' !default;


### PR DESCRIPTION
### 🎯 Goal

If an integrator does a custom style bundling (instead of importing the `index.scss`) they might need to set a custom asset path

### 🛠 Implementation details

_Provide a description of the implementation_

### 🎨 UI Changes

_Add relevant screenshots_

Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
