### PR TITLE
fix: adjust MessageInput Autocomplete position above textarea with multiple rows

### DIFF
--- a/src/v2/styles/Autocomplete/Autocomplete-layout.scss
+++ b/src/v2/styles/Autocomplete/Autocomplete-layout.scss
@@ -23,7 +23,7 @@
 // React SDK's version of Angular SDK's .dropup (mention-list)
 .str-chat__suggestion-list-container {
   position: absolute;
-  bottom: var(--str-chat__spacing-7);
+  bottom: calc(100% + var(--str-chat__spacing-2_5));
   width: 100%;
   padding: var(--str-chat__spacing-2) 0;
 


### PR DESCRIPTION
### 🎯 Goal

Make sure the autocomplete suggestion list is always above the textarea.



### 🎨 UI Changes

Before:
![image](https://github.com/GetStream/stream-chat-css/assets/32706194/6c3e519b-9472-4d93-9938-860688e01906)


After:

![image](https://github.com/GetStream/stream-chat-css/assets/32706194/29b35105-afcd-4578-9107-647fc21211a8)
