### PR TITLE
fix(ThreadListItem): add text overflow for long user names

### DIFF
--- a/src/v2/styles/ThreadList/ThreadList-layout.scss
+++ b/src/v2/styles/ThreadList/ThreadList-layout.scss
@@ -100,9 +100,12 @@
     }
 
     .str-chat__thread-list-item__latest-reply-created-by {
-      display: flex;
       font-weight: 500;
       font-size: 16px;
+      text-align: left;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow-x: hidden;
     }
 
     .str-chat__thread-list-item__latest-reply-text-and-timestamp {


### PR DESCRIPTION
### 🎨 UI Changes
Before:
![localhost_3000_chat_docs_sdk_react_v11-legacy_](https://github.com/user-attachments/assets/67eb723e-6713-4bb7-a937-cb9c1e994cf3)
After:
![localhost_3000_chat_docs_sdk_react_v11-legacy_ (1)](https://github.com/user-attachments/assets/1bf38253-5baa-4b19-81ad-5ab4cd6a7ae3)
