### PR TITLE
fix: remove hover styles for touch devices inside the message menu

### DIFF
--- a/src/v2/styles/MessageActionsBox/MessageActionsBox-theme.scss
+++ b/src/v2/styles/MessageActionsBox/MessageActionsBox-theme.scss
@@ -67,3 +67,11 @@
     }
   }
 }
+
+@media (hover: none) {
+  .str-chat__message-actions-box {
+    .str-chat__message-actions-list-item-button:hover {
+      background-color: transparent;
+    }
+  }
+}

--- a/src/v2/styles/MessageReactions/MessageReactionsSelector-theme.scss
+++ b/src/v2/styles/MessageReactions/MessageReactionsSelector-theme.scss
@@ -84,5 +84,11 @@
         background-color: var(--str-chat__message-reactions-option-selected-background-color);
       }
     }
+
+    @media (hover: none) {
+      .str-chat__message-reactions-option:hover {
+        background-color: transparent;
+      }
+    }
   }
 }


### PR DESCRIPTION
### 🎯 Goal

On touch devices, you don't need special styles for hover action. However, mobile OS-es still handle the `:hover` CSS selector, but it can be confusing to the user when they accidentally activate the `:hover` selector, this PR removes the `:hover` styles for touch devices inside the message menu.

### 🛠 Implementation details

_Provide a description of the implementation_

### 🎨 UI Changes

_Add relevant screenshots_

Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
