### PR TITLE
fix: z-index inside attachment preview

### DIFF
--- a/src/v2/styles/AttachmentPreviewList/AttachmentPreviewList-layout.scss
+++ b/src/v2/styles/AttachmentPreviewList/AttachmentPreviewList-layout.scss
@@ -114,7 +114,7 @@
     top: calc(var(--str-chat__spacing-px) * 2);
     inset-inline-end: calc(var(--str-chat__spacing-px) * 2);
     cursor: pointer;
-    z-index: 1;
+    z-index: 0;
 
     svg {
       width: calc(var(--str-chat__spacing-px) * 24);
@@ -128,7 +128,7 @@
     @include utils.unset-button(unset);
     inset-inline-start: 0;
     cursor: pointer;
-    z-index: 1;
+    z-index: 0;
   }
 }
 


### PR DESCRIPTION
### 🎯 Goal

This PR affects both Angular and React (I tested with the React vite example app).

Issue: the delete and retry icons had higher z-index than the channel list menu, causing a visual glitch

<img width="652" alt="Screenshot 2024-10-03 at 10 19 27" src="https://github.com/user-attachments/assets/bff6e0e2-b921-4f2f-866a-4fc8069fde1d">
