### PR TITLE
docs: remove extra erroneous section

### DIFF
--- a/docs/theming/introduction.mdx
+++ b/docs/theming/introduction.mdx
@@ -20,7 +20,6 @@ import ChatUiRtlScreenshot from '../assets/stream-chat-css-rtl-layout-screenshot
 
 The SDK provides default CSS, which can be overridden by the integrators.
 
-
 ## Importing the stylesheet
 
 If you're using SCSS:
@@ -198,7 +197,6 @@ To solve this we also have to set the text color for the link attachment compone
 
 <img src={MessageCustomColor2Screenshot} width='500' />
 
-
 <SDKSpecific name="angular">
 ### Custom icons
 
@@ -273,16 +271,6 @@ If the default rules set by the stream-chat-angular stylesheets not enough to se
 
 <SDKSpecific name="todo-react">
 ### Custom icons
-
-</SDKSpecific>
-
-### CSS overrides
-
-If you'd like to add customizations that are not supported by CSS variables, you can override parts of the default CSS:
-
-<SDKSpecific name="react">
-
-TODO
 
 </SDKSpecific>
 


### PR DESCRIPTION
### 🎯 Goal

Removes `CSS overrides` section from the docs which was probably added by mistake during a conflict resolution.