### PR TITLE
fix: white space inconsistency in quoted messages, clamp quoted messages

### DIFF
--- a/src/v2/styles/Message/Message-layout.scss
+++ b/src/v2/styles/Message/Message-layout.scss
@@ -23,6 +23,9 @@
     var(--str-chat__quoted-message-inside-message-input-max-width) +
       calc(var(--str-chat__spacing-px) * 50)
   );
+
+  /* The maximum number of lines displayed for quoted messages, set to "none" to turn off clamping */
+  --str-chat__quoted-message-line-clamp: 5;
 }
 
 .str-chat__message {
@@ -59,12 +62,21 @@
   }
 }
 
+.str-chat__quoted-message-text-value {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: var(--str-chat__quoted-message-line-clamp);
+  line-clamp: var(--str-chat__quoted-message-line-clamp);
+  -webkit-box-orient: vertical;
+}
+
 .str-chat__message,
 .str-chat__quoted-message-preview {
   @mixin chat-bubble-spacing {
     padding: var(--str-chat__spacing-2) var(--str-chat__spacing-4);
 
     p {
+      white-space: pre-line;
       margin: 0;
     }
   }
@@ -164,10 +176,6 @@
 
         .str-chat__message-text-inner {
           @include utils.prevent-glitch-text-overflow;
-        }
-
-        p {
-          white-space: pre-line;
         }
       }
     }
@@ -356,7 +364,6 @@
     display: flex;
   }
 }
-
 
 .str-chat__message-inner {
   .str-chat__message-options {


### PR DESCRIPTION
### 🎯 Goal

- White spaces were treated differently in quoted messages
- Adds clamping to quoted message

See screenshot for details

Merge this if you want the fix for React as well: https://github.com/GetStream/stream-chat-react/pull/2601

### 🛠 Implementation details

_Provide a description of the implementation_

### 🎨 UI Changes

**White space incosistencies**

If we quoted a message with line-breaks before...

![Screenshot 2025-01-14 at 14 18 45](https://github.com/user-attachments/assets/223a655c-4c27-4b44-8dc5-b702c47e9b38)

...the line breaks were not properly preserved in the quote preview:

![Screenshot 2025-01-14 at 14 18 50](https://github.com/user-attachments/assets/46ce8fc1-4569-4fef-9a62-b05727173cc3)

**Clamping**

Without message clamping quoted messages can take up a lot of space:

![Screenshot 2025-01-14 at 14 12 04](https://github.com/user-attachments/assets/19e6efdb-1b15-4471-a18d-14d0fc08c711)

With message clamping:

![Screenshot 2025-01-14 at 14 12 11](https://github.com/user-attachments/assets/d3b7f685-8f99-4682-85f5-76b3c14b8447)


