### PR TITLE
fix: add margin only to other users' messages without open actions dialog

### DIFF
--- a/src/v2/styles/Message/Message-layout.scss
+++ b/src/v2/styles/Message/Message-layout.scss
@@ -375,7 +375,7 @@
   }
 }
 
-.str-chat__message--other .str-chat__message-inner {
+.str-chat__message--other .str-chat__message-inner:not(:has(.str-chat__message-options--active)) {
   margin-inline-end: var(--str-chat-message-options-size);
 }
 


### PR DESCRIPTION
### 🎯 Goal

Applies to React SDK only. The SDK displays the message actions dialog over an overlay. Once the overlay is displayed, the message hover styles are removed. Other users' messages that are not hovered over are applied margin on inline-end as a placeholder for message options. This PR fixes the state, when rendering the said overlay leads the message options being displayed with margin on inline-end. In narrow layouts this leads to message component jumping.

Fixes REACT-268
