### PR TITLE
fix: move mention styling outside message

### DIFF
--- a/src/v2/styles/Message/Message-theme.scss
+++ b/src/v2/styles/Message/Message-theme.scss
@@ -191,17 +191,17 @@
   }
 }
 
+.str-chat__message-mention {
+  color: var(--str-chat__message-mention-color);
+  font: var(--str-chat__body2-medium-text);
+}
+
 .str-chat__message {
   @include utils.component-layer-overrides('message');
 
   a {
     text-decoration: none;
     color: var(--str-chat__message-link-color);
-  }
-
-  .str-chat__message-mention {
-    color: var(--str-chat__message-mention-color);
-    font: var(--str-chat__body2-medium-text);
   }
 
   .str-chat__message-bubble {


### PR DESCRIPTION
### 🎯 Goal

Adjust styling of the mention span element so it gets picked up within message, quoted message and quoted message within message input.

Before:
![image](https://github.com/user-attachments/assets/e67623ab-a660-4ed1-be73-5ecfebdeb6fa)
After:
![image](https://github.com/user-attachments/assets/c955a11e-2309-4847-b3d2-791dbb1cb0bd)
