### PR TITLE
fix: enable focus through message options when message reactions are displayed

### DIFF
--- a/src/v2/styles/Message/Message-layout.scss
+++ b/src/v2/styles/Message/Message-layout.scss
@@ -383,6 +383,12 @@
   }
 }
 
+.str-chat__message-inner:focus-within {
+  .str-chat__message-options {
+    display: flex;
+  }
+}
+
 .str-chat__message--other .str-chat__message-inner:not(:has(.str-chat__message-options--active)) {
   margin-inline-end: var(--str-chat-message-options-size);
 }


### PR DESCRIPTION
### 🎯 Goal

Tabbing through messages avoided focusing message options if the message had reactions.

fixes REACT-388

## Demo

**Incorrect tabbing**

On the way back the options are not focused on message with reaction

[incorrect-tabbing.webm](https://github.com/user-attachments/assets/5a80f36d-2108-4a7f-b97c-e8c91b05dfea)

**Corect tabbing**

On the way back the options are focused on message with reaction

[correct-tabbing.webm](https://github.com/user-attachments/assets/a15f5e48-c13f-44c5-ab2f-70d5d11a28b4)

