### PR TITLE
fix: message shrinking when MessageActions modal is open

### DIFF
--- a/src/v2/styles/Message/Message-layout.scss
+++ b/src/v2/styles/Message/Message-layout.scss
@@ -313,7 +313,8 @@
 .str-chat__virtual-list:not(.str-chat__message-options-in-bubble, .str-chat__message-with-touch-support) {
   /* This rule won't be applied in browsers that don't support :has() */
   .str-chat__li:hover:not(:has(.str-chat__reaction-list:hover, .str-chat__modal--open)),
-  .str-chat__li:focus-within:not(:has(.str-chat__reaction-list:focus-within, .str-chat__modal--open)) {
+  .str-chat__li:focus-within:not(:has(.str-chat__reaction-list:focus-within, .str-chat__modal--open)),
+  .str-chat__li:has(.str-chat__message-options--active) {
     .str-chat__message-options {
       display: flex;
     }


### PR DESCRIPTION
### 🎯 Goal

Message shrinks when the chat window is not wide enough and the `MessageActions` modal gets opened.

### 🎨 UI Changes

Normal:
![image](https://github.com/user-attachments/assets/9ba6eb24-00ad-4b4e-9520-ef4ea3543183)

Opened (before fix):
![image](https://github.com/user-attachments/assets/eb1fb4d9-ea6a-4e5b-9f96-543c72bcad0d)

Opened fixed:
![image](https://github.com/user-attachments/assets/0f8686ad-ff95-4846-bfdb-6735ab1678ee)

