### PR TITLE
feat: add styles for delivery receipts

### DIFF
--- a/src/v2/styles/Message/Message-layout.scss
+++ b/src/v2/styles/Message/Message-layout.scss
@@ -260,6 +260,24 @@
     }
   }
 
+  .str-chat__message-status-sent {
+    --str-chat-icon-height: calc(var(--str-chat__spacing-px) * 12);
+
+    svg {
+      width: var(--str-chat-icon-height);
+      height: var(--str-chat-icon-height);
+    }
+  }
+
+  .str-chat__message-status-delivered {
+    --str-chat-icon-height: calc(var(--str-chat__spacing-px) * 15);
+
+    svg {
+      width: var(--str-chat-icon-height);
+      height: var(--str-chat-icon-height);
+    }
+  }
+
   .str-chat__message-replies-count-button-wrapper,
   .str-chat__message-is-thread-reply-button-wrapper {
     grid-area: replies;

--- a/src/v2/styles/Message/Message-theme.scss
+++ b/src/v2/styles/Message/Message-theme.scss
@@ -344,6 +344,15 @@
     }
   }
 
+  .str-chat__message-status-sent,
+  .str-chat__message-status-delivered {
+    svg {
+      path {
+        fill: var(--str-chat__text-low-emphasis-color);
+      }
+    }
+  }
+
   .str-chat__message-replies-count-button-wrapper,
   .str-chat__message-is-thread-reply-button-wrapper {
     button {


### PR DESCRIPTION
### 🎯 Goal

Add styles for delivered and sent message statuses (need to be smaller than the avatar)

### 🎨 UI Changes

<img width="618" height="543" alt="image" src="https://github.com/user-attachments/assets/5d37b2e1-4adb-4dc8-96cc-82a94d07c840" />

### Msg list impact

None
- [x] Make sure to test with both Angular and React (with both `MessageList` and `VirtualizedMessageList` components) SDKs
