### PR TITLE
feat: add layout styles for str-chat__message-actions-box__submenu

### DIFF
--- a/src/v2/styles/MessageActionsBox/MessageActionsBox-layout.scss
+++ b/src/v2/styles/MessageActionsBox/MessageActionsBox-layout.scss
@@ -1,6 +1,7 @@
 .str-chat__message-actions-box {
   overflow: hidden; // Avoids message action box item background overflow in hovered state
 
+  .str-chat__message-actions-box__submenu,
   .str-chat__message-actions-list {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
### 🎯 Goal

Styles needed for this [PR](https://github.com/GetStream/stream-chat-react/pull/2856) to keep the submenu dimensions the same as the parent menu. By replacing react-popper with floating-ui the styles need to be applied.
