### PR TITLE
fix: remove duplicate padding from .str-chat__modal__suggest-poll-option dialog

### DIFF
--- a/src/v2/styles/Poll/Poll-layout.scss
+++ b/src/v2/styles/Poll/Poll-layout.scss
@@ -177,6 +177,10 @@
       .str-chat__form-field-error {
         height: 1rem;
       }
+
+      .str-chat__dialog__controls {
+        padding-bottom: 0;
+      }
     }
 
     .str-chat__modal__poll-answer-list,


### PR DESCRIPTION
### 🎯 Goal

Avoid bottom padding duplication